### PR TITLE
AWS Fetching

### DIFF
--- a/config/aws.js
+++ b/config/aws.js
@@ -1,0 +1,7 @@
+module.exports = {
+  providerKey: 'aws',
+  providerName: 'Amazon Web Services',
+  hasRegions: true,
+  fetchUrl: 'https://status.aws.amazon.com/data.json',
+  downDetectorIdentifier: 'aws-amazon-web-services'
+}

--- a/config/gcloud.js
+++ b/config/gcloud.js
@@ -1,6 +1,6 @@
 module.exports = {
   providerKey: 'gcloud',
-  providerName: 'GCloud',
+  providerName: 'Google Cloud',
   hasRegions: false,
   fetchUrl: 'https://status.cloud.google.com/incidents.json',
   downDetectorIdentifier: 'google-cloud'

--- a/metadata/regions.js
+++ b/metadata/regions.js
@@ -1,7 +1,0 @@
-module.exports = {
-  aws: [
-    {
-      name: 'eu-west-1'
-    }
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9405,8 +9405,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
       "version": "0.9.0",
@@ -13511,11 +13510,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
-    },
-    "tiny-json-http": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.1.2.tgz",
-      "integrity": "sha512-XB9Bu+ohdQso6ziPFNVqK+pcTt0l8BSRkW/CCBq0pUVlLxcYDsorpo7ae5yPhu2CF1xYgJuKVLF7cfOGeLCTlA=="
     },
     "tinydate": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/YcleptJohn/statuses#readme",
   "dependencies": {
-    "request": "^2.88.2",
-    "require-all": "^3.0.0",
-    "tiny-json-http": "^7.1.2",
+    "node-fetch": "^2.6.0",
     "preact": "^10.3.2",
     "preact-render-to-string": "^5.1.4",
-    "preact-router": "^3.2.1"
+    "preact-router": "^3.2.1",
+    "request": "^2.88.2",
+    "require-all": "^3.0.0"
   },
   "devDependencies": {
     "enzyme": "^3.10.0",

--- a/src/api/examples/aws-maybe-json?.json
+++ b/src/api/examples/aws-maybe-json?.json
@@ -1,0 +1,2615 @@
+{
+  "archive": [
+    {
+      "service_name": "Auto Scaling (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1525914401",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:06 PM PDT</span>&nbsp;We are investigating increased API error rates in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:26 PM PDT</span>&nbsp;We are continuing to investigate increased API error rates in the US-EAST-1 Region</div><div><span class=\"yellowfg\"> 7:24 PM PDT</span>&nbsp;We have identified the root cause of the elevated API error rates and can confirm that most customers have recovered. We are continuing to work towards full resolution.</div><div><span class=\"yellowfg\"> 7:40 PM PDT</span>&nbsp;Between 5:42 PM and 7:04 PM PDT, we experienced increased API error rates in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "autoscaling-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Delayed network provisioning",
+      "date": "1526397141",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:12 AM PDT</span>&nbsp;We are investigating delayed network provisioning for newly launched instances in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 8:45 AM PDT</span>&nbsp;Between 5:27 AM and 8:17 AM PDT we experienced delayed network provisioning for newly launched instances in a single Availability Zone in the US-EAST-1 Region. The issue have been resolved and the service is operating normally. </div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (N. Virginia)",
+      "summary": "[RESOLVED] Increased provisioning times",
+      "date": "1526397279",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:14 AM PDT</span>&nbsp;We are investigating increased provisioning times for load balancers in the US-EAST-1 Region. Registration of back-end instances and connectivity to existing instances are not affected. </div><div><span class=\"yellowfg\"> 8:53 AM PDT</span>&nbsp;Between 6:05 AM and 8:17 AM PDT we experienced delayed network provisioning for newly launched instances in a single Availability Zone in the US-EAST-1 Region. Registration of back-end instances and connectivity to existing instances are not affected. The issue have been resolved and the service is operating normally. </div>",
+      "service": "elb-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (N. Virginia)",
+      "summary": "[RESOLVED] Delays in starting clusters",
+      "date": "1526397532",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:19 AM PDT</span>&nbsp;We are investigating delays in starting Amazon EMR clusters in the US-EAST-1 Region. Existing clusters are not impacted.</div><div><span class=\"yellowfg\"> 8:40 AM PDT</span>&nbsp;Between 7:00 AM and 8:15 AM PDT we experienced delays in starting Amazon EMR clusters in the US-EAST-1 Region. Existing clusters were not impacted. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-us-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Storage Service (N. Virginia)",
+      "summary": "[RESOLVED] Elevated error rates",
+      "date": "1526466746",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:32 AM PDT</span>&nbsp;Between 2:35 AM and 2:39 AM PDT, we experienced elevated error rates for requests in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "s3-us-standard"
+    },
+    {
+      "service_name": "AWS CodeBuild (N. Virginia)",
+      "summary": "[RESOLVED] Increased build error rates",
+      "date": "1526469181",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:13 AM PDT</span>&nbsp;We are investigating increased Build error rates in US-EAST-1 Region. </div><div><span class=\"yellowfg\"> 5:12 AM PDT</span>&nbsp;Between 2:50 AM and 4:55 AM PDT, we experienced elevated Build error rates in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "codebuild-us-east-1"
+    },
+    {
+      "service_name": "Amazon AppStream 2.0 (N. Virginia)",
+      "summary": "[RESOLVED] Increased error rates",
+      "date": "1526472913",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:15 AM PDT</span>&nbsp;We are currently investigating increased error rates in provisioning streaming instances in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 5:22 AM PDT</span>&nbsp;Between 2:50 AM and 5:06 AM PDT, we experienced increased error rates in provisioning streaming instances. The issue has been resolved now and the service is operating normally.</div>",
+      "service": "appstream2-us-east-1"
+    },
+    {
+      "service_name": "AWS Systems Manager (N. Virginia)",
+      "summary": "[RESOLVED] Increased error rates",
+      "date": "1526473109",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:18 AM PDT</span>&nbsp;Between 2:50 AM and 4:55 AM PDT we experienced increased API error rates in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2systemsmanager-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Sao Paulo)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1526569732",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:09 AM PDT</span>&nbsp;We are investigating connectivity issues for some instances in the SA-EAST-1 Region.</div><div><span class=\"yellowfg\"> 8:32 AM PDT</span>&nbsp; Between 7:26 AM and 7:34 AM PDT, and between 7:57 AM to 8:05 AM PDT, some instances experienced connectivity issues in the SA-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-sa-east-1"
+    },
+    {
+      "service_name": "Amazon WorkMail (N. Virginia)",
+      "summary": "[RESOLVED] Increased Outlook Sync Latencies and Errors",
+      "date": "1527016380",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:13 PM PDT</span>&nbsp;We are investigating increased WorkMail Outlook synchronization latencies and error rates in the US-EAST-1 Region impacting the sending and receiving of new messages or appointments in Outlook clients.</div><div><span class=\"yellowfg\">12:30 PM PDT</span>&nbsp;Between 11:06 AM and 12:09 PM PDT we experienced increased WorkMail Outlook synchronization latencies and error rates in the US-EAST-1 Region, impacting the sending and receiving of new messages or appointments in Outlook clients. The issue has been resolved and the service is operating normally.</div>",
+      "service": "workmail-us-east-1"
+    },
+    {
+      "service_name": "Amazon Cognito (N. Virginia)",
+      "summary": "[RESOLVED] Elevated Sign In Error Rates",
+      "date": "1527647488",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:31 PM PDT</span>&nbsp;We are investigating reports that some users are unable to sign in or sign up to applications using Facebook identities with Amazon Cognito User Pools.</div><div><span class=\"yellowfg\"> 8:17 PM PDT</span>&nbsp;Recently, some users were unable to sign in or sign up to applications using Facebook identities with Amazon Cognito User Pools. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cognito-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Ohio)",
+      "summary": "[RESOLVED] Internet Connectivity",
+      "date": "1527752189",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:36 AM PDT</span>&nbsp;We are currently investigating connectivity issues in the US-EAST-2 Region.</div><div><span class=\"yellowfg\"> 1:01 AM PDT</span>&nbsp;Between 12:11 AM and 12:45 AM PDT we experienced impaired Internet connectivity in the US-EAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-2"
+    },
+    {
+      "service_name": "AWS Internet Connectivity (Ohio)",
+      "summary": "[RESOLVED] Internet Connectivity",
+      "date": "1527752941",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:49 AM PDT</span>&nbsp;\r\nWe are currently investigating connectivity issues in the US-EAST-2 Region. </div><div><span class=\"yellowfg\">12:59 AM PDT</span>&nbsp;Between 12:11 AM and 12:45 AM PDT we experienced impaired Internet connectivity in the US-EAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "internetconnectivity-us-east-2"
+    },
+    {
+      "service_name": "Amazon Elastic File System (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1527800578",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:03 PM PDT</span>&nbsp;We are investigating increased error rates for file system requests in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 2:58 PM PDT</span>&nbsp;Between 1:00 PM and 2:29 PM PDT, we experienced increased error rates for file system read/write requests in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticfilesystem-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Instance Connectivity Issues",
+      "date": "1527804823",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:13 PM PDT</span>&nbsp;We are investigating connectivity issues affecting some instances in a single Availability Zone in the US-EAST-1 Region.\r\n</div><div><span class=\"yellowfg\"> 3:42 PM PDT</span>&nbsp;We can confirm that there has been an issue in one of the datacenters that makes up one of US-EAST-1 Availability Zones. This was a result of a power event impacting a small percentage of the physical servers in that datacenter as well as some of the networking devices. Customers with EC2 instances in this availability zone may see issues with connectivity to the affected instances. We are seeing recovery and continue to work toward full resolution.</div><div><span class=\"yellowfg\"> 4:29 PM PDT</span>&nbsp;We have restored power to the vast majority of the affected instances and continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 5:36 PM PDT</span>&nbsp;ï»¿ï»¿Beginning at 2:52 PM PDT a small percentage of EC2 servers lost power in a single Availability Zone in the US-EAST-1 Region. This resulted in some impaired EC2 instances and degraded performance for some EBS volumes in the affected Availability Zone. Power was restored at 3:22 PM PDT, at which point the vast majority of instances and volumes saw recovery. We have been working to recover the remaining instances and volumes. The small number of remaining instances and volumes are hosted on hardware which was adversely affected by the loss of power. While we will continue to work to recover all affected instances and volumes, for immediate recovery, we recommend replacing any remaining affected instances or volumes if possible.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Redshift (N. Virginia)",
+      "summary": "[RESOLVED] Connectivity Issues",
+      "date": "1527806609",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:43 PM PDT</span>&nbsp;We are investigating connectivity issues affecting some Redshift clusters in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 4:07 PM PDT</span>&nbsp;Between 2:52 PM and 3:55 PM PDT we experienced connectivity issues affecting some clusters in a single Availability Zone in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "redshift-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (N. Virginia)",
+      "summary": "[RESOLVED] Connectivity Issues",
+      "date": "1527806975",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:49 PM PDT</span>&nbsp;We are investigating elevated error rates for connections to some WorkSpaces in a single Availability Zone in the US-EAST-1 Region.\r\n</div><div><span class=\"yellowfg\"> 4:18 PM PDT</span>&nbsp;Between 2:52 PM and 4:15 PM PDT we experienced increased error rates for connections to some WorkSpaces in a single Availability Zone in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "workspaces-us-east-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (N. Virginia)",
+      "summary": "[RESOLVED] Connectivity Issues",
+      "date": "1527807509",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:58 PM PDT</span>&nbsp;We are investigating connectivity issues affecting some database instances in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 4:12 PM PDT</span>&nbsp;Beginning at 2:52 PM PDT, we experienced connectivity issues affecting some database instances in a single Availability Zone in the US-EAST-1 Region. Multi-AZ database instances functioned correctly and remain available. A small number of Single-AZ database instances remain unavailable and we are working to resolve the issue.</div><div><span class=\"yellowfg\"> 5:42 PM PDT</span>&nbsp;Beginning at 2:52 PM PDT, we experienced connectivity issues affecting some database instances in a single Availability Zone in the US-EAST-1 Region. Multi-AZ database instances functioned correctly and remained available. Connectivity was restored at 3:22 PM PDT, at which point the vast majority of database instances recovered. A small number of Single-AZ database instances remain unavailable and we are continuing to work to recover all affected database instances.</div>",
+      "service": "rds-us-east-1"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Increased Propagation Time",
+      "date": "1528291058",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:17 AM PDT</span>&nbsp;We are investigating increased propagation times of DNS edits to the Route 53 DNS servers. This does not impact queries to existing DNS records.</div><div><span class=\"yellowfg\"> 6:47 AM PDT</span>&nbsp;Between 5:42 AM and 6:45 AM PDT, we experienced increased propagation times of DNS edits to the Route 53 DNS servers. This did not impact queries to existing DNS records. The issue has been resolved and the service is operating normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Auto Scaling (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1528330928",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:22 PM PDT</span>&nbsp;We are investigating increased error rates for API calls in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 5:33 PM PDT</span>&nbsp;Between 5:05 PM and 5:26 PM PDT we experienced increased error rates for API calls in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "autoscaling-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Delays in propagating certain configuration changes to a few CloudFront Edge locations ",
+      "date": "1528895774",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:16 AM PDT</span>&nbsp;We are investigating longer than usual propagation times to propagate certain configuration changes to a few of our edge locations: the creation and deletion of CloudFront distributions and the updating of certificates for a CloudFront distribution. All other CloudFront configuration changes are propagating normally. End-user requests for content from our edge locations are not affected by this issue and are being served normally. </div><div><span class=\"yellowfg\"> 6:59 AM PDT</span>&nbsp;Between 3:25 AM and 6:45 AM PDT, CloudFront experienced longer than usual propagation times to propagate certain configuration changes to a few of our edge locations. This issue has been resolved and the service is operating normally. During this time, end user requests for content from our edge locations were not affected by this issue and were being served normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates ",
+      "date": "1528907930",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:39 AM PDT</span>&nbsp;We are investigating increased error rates and latencies for ELB APIs in the US-EAST-1 Region. Traffic to existing load balancers is not affected.</div><div><span class=\"yellowfg\">10:11 AM PDT</span>&nbsp;Between 8:59 AM and 9:58 AM PDT we experienced increased error rates and latencies for the ELB APIs in the US-EAST-1 Region. The issue affected load balancer provisioning and target registration for Application and Network Load Balancer. Classic Load Balancer, as well as traffic to all existing load balancers, was not affected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "elb-us-east-1"
+    },
+    {
+      "service_name": "AWS CodeDeploy (N. Virginia)",
+      "summary": "[RESOLVED] Elevated API Error Rates",
+      "date": "1529347567",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:46 AM PDT</span>&nbsp;We are investigating elevated error rates for APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">12:31 PM PDT</span>&nbsp;Between 11:11 AM and 12:00 PM PDT we experienced elevated error rates for APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "codedeploy-us-east-1"
+    },
+    {
+      "service_name": "AWS Cloud9 (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1529609394",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:30 PM PDT</span>&nbsp;Between 11:01 AM and 11:20 AM PDT we experienced increased error rates in creating and accessing Cloud9 environments in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "cloud9-us-east-1"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased Error Rates and Latencies",
+      "date": "1529622992",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:16 PM PDT</span>&nbsp;We are investigating increased error rates and latencies for the IAM APIs.</div><div><span class=\"yellowfg\"> 4:24 PM PDT</span>&nbsp;Between 3:38 PM and 4:11 PM PDT we experienced increased IAM API error rates and latencies. The issue has been resolved and the service is operating normally.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "Amazon Elastic File System (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1530065273",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:08 PM PDT</span>&nbsp;Between 5:14 PM and 6:09 PM PDT, we experienced increased error rates for API requests in the US-EAST-1 Region. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "elasticfilesystem-us-east-1"
+    },
+    {
+      "service_name": "AWS IoT Core (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1530296421",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:20 AM PDT</span>&nbsp;We are investigating increased error rates for connections to AWS IoT Core, affecting some customers in the US-EAST-1 Region. </div><div><span class=\"yellowfg\">11:38 AM PDT</span>&nbsp;We continue to investigate increased error rates for connections to AWS IoT Core, affecting some customers in the US-EAST-1 Region. </div><div><span class=\"yellowfg\">12:02 PM PDT</span>&nbsp;Error rates for connections to AWS IoT Core in the US-EAST-1 Region are improving. We continue to work towards full resolution. </div><div><span class=\"yellowfg\">12:44 PM PDT</span>&nbsp;Between 9:26 AM and 11:56 AM PDT we experienced intermittent elevated error rates for connections to AWS IoT Core in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "awsiot-us-east-1"
+    },
+    {
+      "service_name": "Amazon Chime",
+      "summary": "[RESOLVED] Availability",
+      "date": "1530900123",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:02 AM PDT</span>&nbsp;We are investigating meeting availability issues in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">11:18 AM PDT</span>&nbsp;We continue to investigate meeting availability issues in the US-EAST-1 Region. </div><div><span class=\"yellowfg\">11:49 AM PDT</span>&nbsp;Between 10:24 AM PDT and 11:31 AM PDT, we experienced meeting availability issues in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "chime"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Increased Propagation Time",
+      "date": "1531395752",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:44 AM PDT</span>&nbsp;We are investigating increased propagation times of DNS edits to the Route 53 DNS servers. This does not impact queries to existing DNS records.</div><div><span class=\"yellowfg\"> 5:15 AM PDT</span>&nbsp;We can confirm increased propagation times of DNS edits to the Route 53 DNS servers and continue to work towards resolution. This does not impact queries to existing DNS records.</div><div><span class=\"yellowfg\"> 6:02 AM PDT</span>&nbsp;Propagation of DNS edits for Route 53 records in Public Hosted Zones has recovered. We are still working towards recovery for DNS edits for records in Route 53 Private Hosted Zones.</div><div><span class=\"yellowfg\"> 6:24 AM PDT</span>&nbsp;Between 4:00 AM and 6:14 AM PDT we experienced increased propagation times of DNS edits to a single Route 53 edge location. This does not impact queries to existing DNS records. The issue has been resolved and the service is operating normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "AWS Management Console",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1531774261",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:51 PM PDT</span>&nbsp;We are currently experiencing intermittent errors accessing the AWS Management Console. AWS services are operating normally.</div><div><span class=\"yellowfg\"> 2:10 PM PDT</span>&nbsp;We are currently experiencing intermittent errors accessing the AWS Management Console when using root account login credentials. The underlying AWS services and console logins using IAM users are operating normally.</div><div><span class=\"yellowfg\"> 2:47 PM PDT</span>&nbsp;We have identified the root cause for the intermittent errors accessing the AWS Management Console when using root account login credentials. We are beginning to see recovery, and continue to work toward full resolution. The underlying AWS services and console logins using IAM users continue to operate normally.</div><div><span class=\"yellowfg\"> 3:44 PM PDT</span>&nbsp;Between 12:28 PM and 3:13 PM PDT we experienced intermittent errors accessing the AWS Management Console. AWS services were not affected by this event. This issue has been resolved and the service is operating normally.</div>",
+      "service": "management-console"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Frankfurt)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1531962885",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:14 PM PDT</span>&nbsp;We are investigating connectivity issues to a single Availability Zone in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\"> 6:34 PM PDT</span>&nbsp;Between 5:39 PM and 5:49 PM PDT we experienced network connectivity issues for some instances in a single Availability Zone in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Simple Queue Service (Tokyo)",
+      "summary": "[è§£æ±ºæ¸ˆã¿]SQSã§ã®ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³ãƒªã‚»ãƒƒãƒˆåŠã³ã‚½ã‚±ãƒƒãƒˆã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆã®ç™ºç”Ÿ | [RESOLVED] Connection reset and socket timeout for SQS ",
+      "date": "1533208334",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:12 AM PDT</span>&nbsp;æ—¥æœ¬æ™‚é–“ 2018/08/02 17:30 ã‹ã‚‰ 17:55 ã«ã‹ã‘ã¦ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã® SQS ã«ãŠã„ã¦ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³ãƒªã‚»ãƒƒãƒˆåŠã³ã‚½ã‚±ãƒƒãƒˆã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆã®ç™ºç”ŸçŽ‡ãŒä¸Šæ˜‡ã—ã¾ã—ãŸã€‚å•é¡Œã¯æ—¢ã«è§£æ¶ˆã—ã€ç¾åœ¨ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ã«ç¨¼åƒã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 1:30AM and 1:55 AM PDT we experienced connection resets and socket timeout rates in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally. </div><div><span class=\"yellowfg\"> 4:22 AM PDT</span>&nbsp;æ—¥æœ¬æ™‚é–“ 2018/08/02 17:30 ã‹ã‚‰ 17:55 ã«ã‹ã‘ã¦ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã® SQS ã«ãŠã„ã¦ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³ãƒªã‚»ãƒƒãƒˆåŠã³ã‚½ã‚±ãƒƒãƒˆã‚¿ã‚¤ãƒ ã‚¢ã‚¦ãƒˆã®ç™ºç”ŸçŽ‡ãŒä¸Šæ˜‡ã—ã¾ã—ãŸã€‚å•é¡Œã¯æ—¢ã«è§£æ¶ˆã—ã€ç¾åœ¨ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ã«ç¨¼åƒã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 1:30AM and 1:55 AM PDT we experienced connection resets and socket timeout rates in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "sqs-ap-northeast-1"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED]  Increased Console and API error rates",
+      "date": "1533545240",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:47 AM PDT</span>&nbsp;Between 12:49 AM and 1:04 AM PDT customers using the Route 53 console and API experienced an elevated error rate. The issue has been resolved and both the Route 53 console and API are operating normally. Route 53 DNS and health checks were both operating normally during this time.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Instance launch errors and connectivity issues",
+      "date": "1533674185",
+      "status": 0,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:49 PM PDT</span>&nbsp;Between 1:06 PM and 1:33 PM PDT we experienced increased error rates for new instance launches and intermittent network connectivity issues for some running instances in a single Availability Zone in the US-EAST-1 Region. The issue has been resolved and the service is operating normally</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Notification Service (Tokyo)",
+      "summary": "[RESOLVED] SNSã®ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆä¸Šæ˜‡ã«ã¤ã„ã¦ | Elevated error rates for SNS",
+      "date": "1533695504",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:31 PM PDT</span>&nbsp;æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã«ãŠãã¾ã—ã¦ã€ç¾åœ¨SNS Publish APIã®ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆãŒä¸Šæ˜‡ã—ã¦ãŠã‚Šã€åŽŸå› ã‚’èª¿æŸ»ã—ã¦ãŠã‚Šã¾ã™ã€‚| We are currently investigating elevated error rates for the SNS Publish API in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 8:34 PM PDT</span>&nbsp;æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã«ãŠãã¾ã—ã¦ã€æ—¥æœ¬æ™‚é–“ 2018å¹´8æœˆ8æ—¥ 10:47-12:08ã®é–“ã€SNS Publish APIã®ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆãŒä¸Šæ˜‡ã—ã¦ãŠã‚Šã¾ã—ãŸã€‚äº‹è±¡ã¯å¾©æ—§ã—ã€ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ã«ç¨¼åƒã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 6:47 PM and 8:08 PM PDT we experienced elevated error rates for the SNS Publish API in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "sns-ap-northeast-1"
+    },
+    {
+      "service_name": "AWS Management Console",
+      "summary": "[RESOLVED] ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®ä¸Šæ˜‡ã«ã¤ã„ã¦ | Elevated Error Rates",
+      "date": "1533696595",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:50 PM PDT</span>&nbsp;æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã«ãŠãã¾ã—ã¦ã€AWS ãƒžãƒã‚¸ãƒ¡ãƒ³ãƒˆã‚³ãƒ³ã‚½ãƒ¼ãƒ«ã®ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆãŒä¸Šæ˜‡ã—ã¦ãŠã‚Šã€åŽŸå› ã‚’èª¿æŸ»ã—ã¦ãŠã‚Šã¾ã™ã€‚| We are investigating elevated error rates for the AWS Management Console in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 8:26 PM PDT</span>&nbsp;æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã«ãŠãã¾ã—ã¦ã€æ—¥æœ¬æ™‚é–“ 2018å¹´8æœˆ8æ—¥ 10:47-12:08ã«ã‹ã‘ã¦ AWS ãƒžãƒãƒ¼ã‚¸ãƒ¡ãƒ³ãƒˆã‚³ãƒ³ã‚½ãƒ¼ãƒ«ã®ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆãŒä¸Šæ˜‡ã—ã¦ãŠã‚Šã¾ã—ãŸã€‚äº‹è±¡ã¯å¾©æ—§ã—ã€ã‚³ãƒ³ã‚½ãƒ¼ãƒ«ã¯æ­£å¸¸ã«ç¨¼åƒã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 6:47 PM and 8:08 PM PDT, users experienced elevated error rates for the AWS Management Console in the AP-NORTHEAST-1 Region. The issue has been resolved and the Console is operating normally. </div>",
+      "service": "management-console"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Mumbai)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533722524",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:02 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the AP-SOUTH-1 Region.</div><div><span class=\"yellowfg\"> 4:13 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the AP-SOUTH-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-ap-south-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Paris)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533722689",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:05 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the EU-WEST-3 Region.</div><div><span class=\"yellowfg\"> 4:16 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the EU-WEST-3 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-eu-west-3"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Ohio)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533722825",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:07 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the US-EAST-2 Region.</div><div><span class=\"yellowfg\"> 4:18 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the US-EAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-us-east-2"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (N. Virginia)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533722962",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:09 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 4:19 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Ireland)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533723112",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:12 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 4:21 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Frankfurt)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533723257",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:14 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the EU-CENTRAL-1 Region</div><div><span class=\"yellowfg\"> 4:23 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (N. California)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533723374",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:16 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the US-WEST-1 Region.</div><div><span class=\"yellowfg\"> 4:26 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the US-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-us-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Singapore)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533723484",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:18 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the AP-SOUTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 4:29 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the AP-SOUTHEAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-ap-southeast-1"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Sydney)",
+      "summary": "[RESOLVED] Failures in starting clusters",
+      "date": "1533723818",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:23 AM PDT</span>&nbsp;We are investigating increased error rates impacting start up of clusters operations in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 4:31 AM PDT</span>&nbsp;Between 5:10 PM on August 7th, and 3:50 AM PDT on August 8th, we experienced increased error rates in starting clusters in the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-ap-southeast-2"
+    },
+    {
+      "service_name": "AWS CodeDeploy (Ireland)",
+      "summary": "[RESOLVED] Increased Deployment Latencies",
+      "date": "1534782477",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:28 AM PDT</span>&nbsp;We are investigating increased deployment latencies in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 9:59 AM PDT</span>&nbsp;Between 7:27 AM and 9:56 AM PDT we experienced increased deployment latencies in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "codedeploy-eu-west-1"
+    },
+    {
+      "service_name": "AWS Single Sign-On (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates and Latencies",
+      "date": "1534799678",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:15 PM PDT</span>&nbsp;We can confirm increased error rates and latencies for the SSO service in the US-EAST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 2:39 PM PDT</span>&nbsp;Between 10:30 AM and 2:18 PM PDT we experienced increased error rates and latencies for the SSO service in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "sso-us-east-1"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Call quality degradation",
+      "date": "1534866429",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:47 AM PDT</span>&nbsp;We are investigating degraded call quality in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 9:21 AM PDT</span>&nbsp;Between 7:10 AM and 8:55 AM PDT, we experienced degraded call quality in the US-EAST-1 Region. Agents and end-customers may have experienced increased call latency or static on calls during this time. The issue has been resolved and the service is operating normally. </div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "Amazon Cognito (Oregon)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1535399349",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:49 PM PDT</span>&nbsp;We are investigating increased error rates for API calls for Cognito User Pools in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 1:16 PM PDT</span>&nbsp;We can confirm increased error rates for API calls for Cognito User Pools in the US-WEST-2 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 1:34 PM PDT</span>&nbsp;Between 11:33 AM and 1:25 PM PDT we experienced increased error rates for API calls for Cognito User Pools in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cognito-us-west-2"
+    },
+    {
+      "service_name": "Amazon Simple Queue Service (N. Virginia)",
+      "summary": "[RESOLVED] Elevated error rates for SQS",
+      "date": "1536163992",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:13 AM PDT</span>&nbsp;We are currently investigating elevated error rates for SQS in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 9:30 AM PDT</span>&nbsp;Between 7:38 AM and 9:18 AM PDT, we experienced elevated API error rates and connection failures in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "sqs-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkMail (N. Virginia)",
+      "summary": "[RESOLVED] Degraded WorkMail performance",
+      "date": "1536725279",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:08 PM PDT</span>&nbsp;We are investigating degraded WorkMail service performance in the US-EAST-1 Region, impacting IMAP client usability and synchronization of messages.\r\nThere is no impact to Outlook, EWS client applications or mobile clients.</div><div><span class=\"yellowfg\"> 9:40 PM PDT</span>&nbsp;We have identified the cause of degraded WorkMail service performance in the US-EAST-1 Region, impacting IMAP client usability and synchronization of messages and continue working towards resolution. There is no impact to Outlook, EWS client applications or mobile clients.</div><div><span class=\"yellowfg\"> 9:59 PM PDT</span>&nbsp;Between 7:10 PM and 9:46 PM PDT we experienced degraded WorkMail service performance in the US-EAST-1 Region, impacting IMAP client usability and synchronization of messages. The issue has been resolved and the service is operating normally.</div>",
+      "service": "workmail-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Ireland)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1537949151",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:06 AM PDT</span>&nbsp;We are investigating increased error rates for new launches in the EU-WEST-1 Region.\r\n\r\n</div><div><span class=\"yellowfg\"> 1:37 AM PDT</span>&nbsp;We can confirm increased API error rates and connectivity issues for some instances in a single Availability Zone in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 2:14 AM PDT</span>&nbsp;We continue to investigate connectivity issues from some instances to some AWS services in the EU-WEST-1 Region. We have identified the root cause and are taking steps to resolve the issue.</div><div><span class=\"yellowfg\"> 3:03 AM PDT</span>&nbsp;We have resolved the connectivity issues from EC2 instances to the affected AWS services in the EU-WEST-1 Region. We continue to see elevated error rates for the RunInstances EC2 API, which we are working to resolve. Internet connectivity and connectivity between EC2 instances remain unaffected.</div><div><span class=\"yellowfg\"> 3:28 AM PDT</span>&nbsp;Starting at 12:15 AM PDT we experienced increased API error rates for the EC2 API, and connectivity issues between EC2 instances and AWS services in the EU-WEST-1 Region. At 2:29 AM PDT, the connectivity issues between EC2 instances and AWS services were resolved. At 2:59 AM PDT, the increased API error rates for the EC2 APIs were fully resolved. Internet connectivity and connectivity between EC2 instances was not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-west-1"
+    },
+    {
+      "service_name": "AWS CloudHSM (Ireland)",
+      "summary": "[RESOLVED] Connectivity issues",
+      "date": "1537956232",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:11 AM PDT</span>&nbsp;We are continuing to investigate connectivity issues impacting CloudHSM and CloudHSM Classic HSMs in a single Availability Zone in EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 3:44 AM PDT</span>&nbsp;We can confirm that current generation CloudHSM instances are operating normally. CloudHSM Classic instances in a single Availability Zone in the EU-WEST-1 Region are experiencing network connectivity errors. As we work to recover the remaining CloudHSM Classic instances, we will continue to provide updates via the Personal Health Dashboard.</div>",
+      "service": "cloudhsm-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic File System (Ireland)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1537958697",
+      "status": 0,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:13 AM PDT</span>&nbsp;Between 12:15 AM and 2:12 AM PDT, we experienced increased error rates for console requests in EU-WEST-1 Region. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "elasticfilesystem-eu-west-1"
+    },
+    {
+      "service_name": "AWS Direct Connect (Ireland)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1537960452",
+      "status": 0,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:19 AM PDT</span>&nbsp;Between 12:15 AM and 2:29 AM PDT, we experienced increased packet loss, impacting AWS Direct Connect connectivity for some customers in the EU-WEST-1 Region. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "directconnect-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Redshift (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1538097782",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:23 PM PDT</span>&nbsp;Between 5:45 PM and 6:10 PM PDT we experienced increased API error rates in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "redshift-us-east-1"
+    },
+    {
+      "service_name": "AWS Internet Connectivity (Frankfurt)",
+      "summary": "[RESOLVED] Network connectivity",
+      "date": "1538413958",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:12 AM PDT</span>&nbsp;We are investigating intermittent connectivity issues between the EU-CENTRAL-1 Region and other AWS Regions.</div><div><span class=\"yellowfg\">10:24 AM PDT</span>&nbsp;We can confirm intermittent issues for Internet and Inter-region network connectivity within the EU-CENTRAL-1 Region. We have mitigated the impact but continue to work towards full resolution.</div><div><span class=\"yellowfg\">10:59 AM PDT</span>&nbsp;Between 9:21 AM and 9:31 AM PDT and between 9:41 AM and 9:51 AM PDT we experienced Internet connectivity issues for the EU-CENTRAL-1 Region and Inter-region connectivity issues between the EU-CENTRAL-1 Region and other AWS regions. The issue has been resolved and the service is operating normally.</div>",
+      "service": "internetconnectivity-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Oregon)",
+      "summary": "[RESOLVED] Increased API Errors ",
+      "date": "1538424731",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:12 PM PDT</span>&nbsp;We are investigating increased error rates and latencies for the EC2 APIs in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 2:06 PM PDT</span>&nbsp;We continue to investigate increased error rates and latencies for the EC2 APIs and EC2 Management Console in the US-WEST-2 Region. Existing EC2 instances are not affected.</div><div><span class=\"yellowfg\"> 3:14 PM PDT</span>&nbsp;We are seeing recovery for the increased error rates and latencies affecting the EC2 APIs in the US-WEST-2 Region. Some requests may return a \"request limit exceeded\" error as we work toward full recovery. We recommend retrying failed requests.</div><div><span class=\"yellowfg\"> 4:41 PM PDT</span>&nbsp;Error rates and latencies for the EC2 APIs in the US-WEST-2 Region remain at normal levels. A small percentage of requests are still returning a \"request limit exceeded\" error as we work toward full recovery. We recommend retrying failed requests.</div><div><span class=\"yellowfg\"> 5:33 PM PDT</span>&nbsp;Starting at 11:20 AM PDT, we experienced periods of increased error rates and latencies for the EC2 APIs in the US-WEST-2 Region. At 2:02 PM PDT, error rates and latencies recovered for the majority of the affected APIs. At 2:55 PM PDT error rates and latencies returned to normal levels but some customers continued to experience \"request limit exceeded\" errors. At 5:10 PM PDT, all error rates, including \"request limit exceeded\" errors, returned to normal levels. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-west-2"
+    },
+    {
+      "service_name": "Auto Scaling (Oregon)",
+      "summary": "[RESOLVED] Increased Launch Latencies ",
+      "date": "1538428181",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:09 PM PDT</span>&nbsp;We are investigating increased launch times for EC2 instances managed by Auto Scaling in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 3:29 PM PDT</span>&nbsp;Between 12:32 PM PDT and 2:40 PM PDT, we experienced elevated launch times for EC2 instance managed by Auto Scaling in the US-WEST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "autoscaling-us-west-2"
+    },
+    {
+      "service_name": "AWS Lambda (Oregon)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1538428351",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:12 PM PDT</span>&nbsp;We are investigating increased error rates for newly created functions in the US-WEST-2 Region. This includes functions created via the console as well as those created via the API or CLI.</div><div><span class=\"yellowfg\"> 3:51 PM PDT</span>&nbsp;We continue to investigate increased error rates for newly created VPC functions in the US-WEST-2 Region. This includes VPC functions created via the console as well as those created via the API or CLI. The issue has been resolved for non-VPC functions. </div><div><span class=\"yellowfg\"> 5:14 PM PDT</span>&nbsp;Between 12:47 PM PDT and 4:55 PM PDT, we experienced increased error rates for newly created functions in US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "lambda-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (Oregon)",
+      "summary": "[RESOLVED] Increased Provisioning Latencies ",
+      "date": "1538428470",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:14 PM PDT</span>&nbsp;We are investigating increased provisioning times for load balancers in the US-WEST-2 Region. Connectivity to existing load balancers is not affected.</div><div><span class=\"yellowfg\"> 3:49 PM PDT</span>&nbsp;We are seeing an improvement in the increased provisioning times affecting load balancers in the US-WEST-2 Region. We continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 5:25 PM PDT</span>&nbsp;Between 1:00 PM and 4:48 PM PDT, we experienced increased provisioning times for load balancers in the US-WEST-2 Region. Connectivity to load balancers was not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elb-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic MapReduce (Oregon)",
+      "summary": "[RESOLVED] Delays in starting clusters",
+      "date": "1538429178",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:26 PM PDT</span>&nbsp;We are investigating delays in starting clusters in the US-WEST-2 Region. Existing clusters are not affected.</div><div><span class=\"yellowfg\"> 3:53 PM PDT</span>&nbsp;We continue to investigate delays in starting clusters in the US-WEST-2 Region. Existing clusters are not affected. </div><div><span class=\"yellowfg\"> 5:11 PM PDT</span>&nbsp;Between 1:10 PM and 4:20 PM PDT we experienced delays in starting clusters in US-West-2 Region. Existing clusters were not affected. The issue has been resolved and the service is operating normally.</div><div><span class=\"yellowfg\"> 5:17 PM PDT</span>&nbsp;Between 1:10 PM and 4:20 PM PDT we experienced delays in starting clusters in US-WEST-2 Region. Existing clusters were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "emr-us-west-2"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (Oregon)",
+      "summary": "[RESOLVED] Increased Provisioning Error Rates",
+      "date": "1538430961",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:56 PM PDT</span>&nbsp;We are investigating increased error rates and latencies for provisioning new WorkSpaces in the US-WEST-2 Region</div><div><span class=\"yellowfg\"> 3:21 PM PDT</span>&nbsp;Between 1:00 PM and 3:00 PM PDT, we experienced increased error rates for new WorkSpaces provisioning in the US-WEST-2 Region. Existing WorkSpaces were unaffected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "workspaces-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Oregon)",
+      "summary": "[RESOLVED] Increased API Errors",
+      "date": "1538626579",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:16 PM PDT</span>&nbsp;We're investigating increased error rates and latencies for the EC2 APIs in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 9:45 PM PDT</span>&nbsp;Between 8:48 PM and 9:25 PM PDT we experienced increased error rates and latencies in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-west-2"
+    },
+    {
+      "service_name": "AWS Secrets Manager (Oregon)",
+      "summary": "[RESOLVED] Elevated latencies and API Error Rates",
+      "date": "1538645129",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:25 AM PDT</span>&nbsp;We are investigating elevated latencies and API error rates in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 3:09 AM PDT</span>&nbsp;We continue to investigate elevated latencies and API error rates in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 8:04 AM PDT</span>&nbsp;Between 2:04 AM and 7:50 AM PDT we experienced increased API error rates and latencies in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "secretsmanager-us-west-2"
+    },
+    {
+      "service_name": "Amazon Simple Storage Service (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1538766090",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:01 PM PDT</span>&nbsp;We are investigating increased error rates for Amazon S3 requests in the US-EAST-2 Region.</div><div><span class=\"yellowfg\">12:16 PM PDT</span>&nbsp;We have identified the root cause of the increased error rates in the US-EAST-2 Region and are working towards resolution.</div><div><span class=\"yellowfg\">12:42 PM PDT</span>&nbsp;We have identified the root cause and are seeing some recovery. We are continuing to monitor and work towards full resolution.</div><div><span class=\"yellowfg\">12:51 PM PDT</span>&nbsp;Between 11:47 AM and 12:33 PM PDT we experienced increased error rates for Amazon S3 requests in the US-EAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "s3-us-east-2"
+    },
+    {
+      "service_name": "Amazon Glacier (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1538768132",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:35 PM PDT</span>&nbsp;We are investigating increased error rates and latency in the US-EAST-2 Region. </div><div><span class=\"yellowfg\">12:48 PM PDT</span>&nbsp;Between 11:47 AM PDT and 12:33 PM PDT we experienced increased API error rates and latencies in the US-EAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "glacier-us-east-2"
+    },
+    {
+      "service_name": "Amazon Kinesis Firehose (Ohio)",
+      "summary": "[RESOLVED] Delayed Data Delivery",
+      "date": "1538768432",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:40 PM PDT</span>&nbsp;We are investigating delays in S3 delivery for Kinesis Firehose in the US-EAST-2 Region.</div><div><span class=\"yellowfg\"> 1:01 PM PDT</span>&nbsp;Between 11:47 AM and 12:38 PM PDT we experienced increased Firehose to S3 delivery delays in the US-EAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "firehose-us-east-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Ohio)",
+      "summary": "[RESOLVED] Degraded Volume Performance for EBS Volumes / Insufficient-Data for EC2 Instance Status Checks",
+      "date": "1538769418",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:57 PM PDT</span>&nbsp;Between 11:47 AM and 12:33 PM PDT we experienced degraded performance for some EBS volumes in the US-EAST-2 Region. During this time, some customers also experienced insufficient-data in the results from EC2 instance status checks. CloudWatch alarms may have transitioned into \"INSUFFICIENT_DATA\" state if set on the delayed metrics. EC2 instances operated normally during this time; only EC2 CloudWatch metrics were affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-2"
+    },
+    {
+      "service_name": "AWS CodeCommit (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1538769625",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:00 PM PDT</span>&nbsp;Between 11:47 AM PDT and 12:33 PM PDT we experienced an increased error rate for APIs and Git Push/Pull in the US-EAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "codecommit-us-east-2"
+    },
+    {
+      "service_name": "Amazon Elastic Container Service (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1538770316",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:12 PM PDT</span>&nbsp;Between 11:47 AM and 12:33 PM PDT we experienced increased error rates when launching Fargate tasks in the US-EAST-2 Region. Running tasks were not impacted. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ecs-us-east-2"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Increased Errors",
+      "date": "1538776626",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:57 PM PDT</span>&nbsp;We are currently investigating increased latencies and errors for the Agent Call Control Panel in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 3:08 PM PDT</span>&nbsp;Between 11:27 AM and 2:52 PM PDT, we experienced increased latencies and errors for the Agent Call Control Panel in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Title: Increased Launch Errors ",
+      "date": "1539093649",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:01 AM PDT</span>&nbsp;Between 5:31 AM and 6:42 AM PDT we experienced increased error rates for instance launches in a single availability zone in the US-EAST-1 Region. Existing instances were unaffected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elasticsearch Service (N. California)",
+      "summary": "[RESOLVED] Domain Connectivity",
+      "date": "1539650824",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:50 PM PDT</span>&nbsp;We are investigating connectivity issues for some domains in the US-WEST-1 Region.</div><div><span class=\"yellowfg\"> 6:35 PM PDT</span>&nbsp;Between 4:50 PM and 6:20 PM PDT we experienced domain connectivity issues in the US-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticsearch-us-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1539804061",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:22 PM PDT</span>&nbsp;We are investigating network connectivity issues for some instances within the US-EAST-1 Region.</div><div><span class=\"yellowfg\">12:30 PM PDT</span>&nbsp;Between 11:27 AM and 11:28 AM PDT some instances experienced connectivity issues for network traffic between Availability Zones within the US-EAST-1 Region. The issue was automatically mitigated and we continue to monitor all affected instances. </div><div><span class=\"yellowfg\"> 1:06 PM PDT</span>&nbsp;Between 11:27 AM and 11:28 AM PDT some instances experienced connectivity issues for network traffic between Availability Zones within the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (N. Virginia)",
+      "summary": "[RESOLVED] Increased provisioning and registration times ",
+      "date": "1539806007",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:53 PM PDT</span>&nbsp;We are investigating increased provisioning and back-end target registration times for load balancers within the US-EAST-1 Region. Connectivity to existing load balancers is not affected.</div><div><span class=\"yellowfg\"> 2:18 PM PDT</span>&nbsp;We continue to work on resolving the increased provisioning and back-end target registration times for Classic and Application Load Balancers within the US-EAST-1 Region. Provisioning and back-end target registration times are not affected for Network Load Balancers. Connectivity to all load balancers is not affected.</div><div><span class=\"yellowfg\"> 2:59 PM PDT</span>&nbsp;Beginning at 11:50 AM PDT we experienced increased provisioning times for Classic and Application Load Balancers within the US-EAST-1 Region. At 12:40 PM PDT, registration times for new back-end targets began to increase. At 2:05 PM PDT, both load balancer provisioning and back-end target registration latencies began to recover. By 2:25 PM PDT, back-end target registration times had returned to normal levels and by 2:44 PM PDT load balancer provisioning had fully recovered. Connectivity to load balancers was not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elb-us-east-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (N. Virginia)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1539806429",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:02 PM PDT</span>&nbsp;Between 11:28 AM and 11:31 AM PDT some Multi-AZ and Single-AZ RDS instances experienced network connectivity issues in the US-EAST-1 Region. All affected Multi-AZ RDS instances failed over to a second Availability Zone, which restored connectivity. The majority of the Single-AZ RDS instances have recovered and we continue to work on restoring connectivity to a small number of remaining Single-AZ RDS instances.\r\n</div><div><span class=\"yellowfg\"> 1:28 PM PDT</span>&nbsp;Between 11:28 AM and 11:31 AM PDT some Multi-AZ and Single-AZ RDS instances experienced network connectivity issues in the US-EAST-1 Region. All affected Multi-AZ RDS instances failed over to a second Availability Zone, which restored connectivity. The remaining Single-AZ RDS instances have now restored connectivity. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-us-east-1"
+    },
+    {
+      "service_name": "Auto Scaling (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates ",
+      "date": "1539810083",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:02 PM PDT</span>&nbsp;We are experiencing increased API error rates and delayed group scaling in the US-EAST-1 Region. Connectivity to existing EC2 Instances is not affected.</div><div><span class=\"yellowfg\"> 3:45 PM PDT</span>&nbsp;We have identified the root cause of the increased API error rates and delayed group scaling in the US-EAST-1 Region. We are beginning to see recovery and continue to work toward full resolution. </div><div><span class=\"yellowfg\"> 4:07 PM PDT</span>&nbsp;Between 11:28 AM and 4:05 PM PDT we experienced increased API error rates and delayed group scaling in the US-EAST-1 Region. Connectivity to existing EC2 Instances was not affected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "autoscaling-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. California)",
+      "summary": "[RESOLVED] Increased API Error Rates and Latencies",
+      "date": "1539971754",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:56 AM PDT</span>&nbsp;We are investigating increased API error rates and latencies in the US-WEST-1 Region. </div><div><span class=\"yellowfg\">11:27 AM PDT</span>&nbsp;Between 10:22 AM and 10:33 AM PDT, and between 10:47 AM and 11:06 AM PDT, we experienced increased API error rates and latencies in the US-WEST-1 Region. APIs also returned insufficient-data in the results from EC2 instance status checks and CloudWatch alarms transitioned into \"INSUFFICIENT_DATA\" state if set on the delayed metrics. EC2 instances operated normally during this time. The issue has been resolved and the service is operating normally. </div>",
+      "service": "ec2-us-west-1"
+    },
+    {
+      "service_name": "Amazon Simple Storage Service (N. California)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1539972265",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:04 AM PDT</span>&nbsp;We are investigating increased error rates for Amazon S3 requests in the US-WEST-1 Region.</div><div><span class=\"yellowfg\">11:19 AM PDT</span>&nbsp;Between 10:22 AM and 10:33 AM PDT, and between 10:47 AM and 11:06 AM PDT, we experienced elevated failure rates for some Amazon S3 requests in the US-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "s3-us-west-1"
+    },
+    {
+      "service_name": "Amazon DynamoDB (N. California)",
+      "summary": "[RESOLVED] Elevated Failure Rates",
+      "date": "1539973333",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:22 AM PDT</span>&nbsp;Between 10:22 AM and 10:33 AM PDT, and between 10:47 AM and 11:06 AM PDT, we experienced elevated failure rates for some Amazon DynamoDB requests in the US-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "dynamodb-us-west-1"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Degraded Metrics Performance",
+      "date": "1540316843",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:47 AM PDT</span>&nbsp;We are investigating delays in forming contact trace records, and degraded service for the metrics and call recording UI in the US-EAST-1 Region. Call handling is not affected.</div><div><span class=\"yellowfg\">11:16 AM PDT</span>&nbsp;We continue to investigate delays in forming contact trace records, and degraded performance of the metrics and call recording search experience in the US-EAST-1 region. Call handling is not affected.</div><div><span class=\"yellowfg\">12:11 PM PDT</span>&nbsp;Between 9:50 AM and 11:40 AM PDT, we experienced delays in forming contact trace records, and degraded performance of the metrics and call recording search experience in the US-EAST-1 Region. No metrics or call recordings were lost, and call handling was not affected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (Ireland)",
+      "summary": "[RESOLVED] Connection errors",
+      "date": "1540431788",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:43 PM PDT</span>&nbsp;We are investigating increased error rates when connecting to WorkSpaces in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 7:18 PM PDT</span>&nbsp;We can confirm increased error rates when connecting to WorkSpaces in the EU-WEST-1 Region. Connections using WorkSpaces Web Access are not affected by this issue.</div><div><span class=\"yellowfg\"> 7:57 PM PDT</span>&nbsp;We have identified the cause of increased error rates when connecting to some WorkSpaces in the EU-WEST-1 Region and continue working towards resolution. Connections using WorkSpaces Web Access are not affected by this issue.</div><div><span class=\"yellowfg\">10:05 PM PDT</span>&nbsp;We have identified the cause of increased error rates when connecting to some WorkSpaces in the EU-WEST-1 Region and are in process of resolving. Connections using WorkSpaces Web Access are not affected by this issue.</div><div><span class=\"yellowfg\">10:29 PM PDT</span>&nbsp;We experienced an issue causing increased error rates when connecting to WorkSpaces from native clients in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "workspaces-eu-west-1"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased API Latencies",
+      "date": "1540486732",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:59 AM PDT</span>&nbsp;We are investigating an increased latency on administrative APIs. Create, Delete, List, Get, and Update API actions may be impacted in multiple regions. Other AWS services whose features require IAM roles will also be impacted. User authentications and authorizations are not impacted.</div><div><span class=\"yellowfg\">10:40 AM PDT</span>&nbsp;We continue to investigate increased latency on administrative APIs. Create, Delete, List, Get, and Update API actions may be impacted in multiple regions. Other AWS services like AWS CloudFormation and AWS Lambda that use IAM roles may also be impacted. User authentications and authorizations are not impacted. </div><div><span class=\"yellowfg\">11:31 AM PDT</span>&nbsp;We have identified the root cause and are working towards a resolution for increased latency on administrative APIs. Create, Delete, List, Get, and Update API actions may be impacted in multiple regions. Other AWS services like AWS CloudFormation and AWS Lambda that use IAM roles may also be impacted. User authentications and authorizations are not impacted.</div><div><span class=\"yellowfg\">12:40 PM PDT</span>&nbsp;We are seeing improvement in the latency for administrative APIs (Create, Delete, List, Get, and Update). We are continuing to work towards a full resolution. User authentications and authorizations are not impacted. </div><div><span class=\"yellowfg\">12:57 PM PDT</span>&nbsp;Between 8:28 AM and 12:31 PM PDT, we experienced increased latency on administrative APIs. Create, Delete, List, Get, and Update API actions were impacted in multiple regions. User authentications and authorizations were not impacted. The issue has been resolved, and the service is operating normally.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED]  Increased Console Error Rates",
+      "date": "1542102750",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:52 AM PST</span>&nbsp;We are investigating increased error rates in the IAM console impacting policy operations for all IAM entities.</div><div><span class=\"yellowfg\"> 2:27 AM PST</span>&nbsp;Between 12:33 AM and 1:33 AM PST we experienced increased error rates in the IAM console impacting policy operations for all IAM entities. The issue has been resolved and the service is operating normally.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "AWS Certificate Manager (Ireland)",
+      "summary": "[RESOLVED] Validation and Issuance Delays for New Certificates",
+      "date": "1542220203",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:31 AM PST</span>&nbsp;We are investigating delays in validating domains for public certificates and delays issuing private certificates requested through ACM in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\">11:23 AM PST</span>&nbsp;We can confirm delays in validating domains for public certificates and delays issuing private certificates requested through ACM in the EU-WEST-1 Region. Existing certificates and previously deployed certificates are unaffected.</div><div><span class=\"yellowfg\">12:22 PM PST</span>&nbsp;We have identified the root cause of delays in validating domains for public certificates and delays issuing private certificates requested through ACM in the EU-WEST-1 Region. We are beginning to see recovery and continue to work toward full resolution. Existing certificates and previously deployed certificates are unaffected.</div><div><span class=\"yellowfg\"> 2:40 PM PST</span>&nbsp;Between 5:45 AM and 1:20 PM PST we experienced delays in validating domains for public certificates and delays issuing private certificates requested through ACM in the EU-WEST-1 Region. Existing certificates and previously deployed certificates were unaffected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "certificatemanager-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Transcribe (Oregon)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1542530957",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:49 AM PST</span>&nbsp;We are investigating increased API error rates in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 1:23 AM PST</span>&nbsp;Between 9:51 PM on November 17th, and 1:02 AM PST on November 18th, we experienced increased API error rates in the US-WEST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "transcribe-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Container Registry (Oregon)",
+      "summary": "[RESOLVED] Elevated API Error Rates",
+      "date": "1542674869",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:48 PM PST</span>&nbsp;We are experiencing elevated error rates for all APIs in the US-WEST-2 Region. </div><div><span class=\"yellowfg\"> 5:14 PM PST</span>&nbsp;We have identified the root cause of the increased API error rates. We are beginning to see recovery, and continue to work towards full resolution.</div><div><span class=\"yellowfg\"> 5:27 PM PST</span>&nbsp;Between 4:02 PM and 5:04 PM PST we experienced increased API error rates for the ECR APIs in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ecr-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API and Launch Error Rates",
+      "date": "1542721813",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:50 AM PST</span>&nbsp;We are investigating increased API and launch error rates in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:20 AM PST</span>&nbsp;Between 5:06 AM and 5:50 AM PST we experienced elevated error rates for instance related APIs and new instance launches in a single Availability Zone in the US-EAST-1 Region. Existing instances were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Storage Service (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542766836",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:20 PM PST</span>&nbsp;Between 5:15 PM and 5:55 PM PST, we experienced intermittent increased error rates for a subset of requests made to the Amazon S3 APIs in the US-EAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "s3-us-east-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Seoul)",
+      "summary": "[RESOLVED] DNS Resolution Issues",
+      "date": "1542844952",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:02 PM PST</span>&nbsp;We are investigating intermittent DNS resolution issues for some instances in the AP-NORTHEAST-2 Region. </div><div><span class=\"yellowfg\"> 4:36 PM PST</span>&nbsp;We have identified the cause of the DNS resolution issues for some instances in the AP-NORTHEAST-2 Region and continue working towards resolution.\r\n</div><div><span class=\"yellowfg\"> 5:01 PM PST</span>&nbsp;Between 3:19 PM and 4:43 PM PST we experienced DNS resolution issues for some instances in the AP-NORTHEAST-2 Region. Some AWS services experienced elevated error rates as a result of this issue. The issue has been resolved and the service is operating normally. <br> <br>Additional details have been provided <a href=\"https://aws.amazon.com/message/74876/\">here</a>. Customers who have questions about this event can contact the AWS Support team by <a href=\"https://aws.amazon.com/support\">opening a case in the AWS Support Center</a>. </div>",
+      "service": "ec2-ap-northeast-2"
+    },
+    {
+      "service_name": "AWS Lambda (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542846560",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:29 PM PST</span>&nbsp;We are investigating increased API error rates in the AP-NORTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:18 PM PST</span>&nbsp;We have identified the root cause and are seeing recovery. We continue to work toward full resolution. </div><div><span class=\"yellowfg\"> 6:19 PM PST</span>&nbsp;Between 3:19 PM and 5:58 PM PST we experienced increased API error rates in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "lambda-ap-northeast-2"
+    },
+    {
+      "service_name": "AWS Elastic Beanstalk (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542847301",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:41 PM PST</span>&nbsp;We are currently investigating increased error rates to Elastic Beanstalk APIs in the AP-NORTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:09 PM PST</span>&nbsp;Between 3:19 PM and 4:43 PM PST we experienced increased error rates in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticbeanstalk-ap-northeast-2"
+    },
+    {
+      "service_name": "Amazon API Gateway (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542847420",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:43 PM PST</span>&nbsp;We are investigating increased error rates for invokes in the AP-NORTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:00 PM PST</span>&nbsp;Between 3:19 PM and 4:43 PM PST we experienced increased error rates in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "apigateway-ap-northeast-2"
+    },
+    {
+      "service_name": "Amazon MQ (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542847452",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:44 PM PST</span>&nbsp;We are investigating increased API error rates in AP-NORTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:20 PM PST</span>&nbsp;We have identified the root cause and are seeing recovery. We continue to work toward full resolution. </div><div><span class=\"yellowfg\"> 5:40 PM PST</span>&nbsp;Between 3:19 PM and 5:28 PM PST we experienced increased API error rates in AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "mq-ap-northeast-2"
+    },
+    {
+      "service_name": "Amazon Kinesis Firehose (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542847565",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:46 PM PST</span>&nbsp;We are investigating increased API fault rates in the AP-NORTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:05 PM PST</span>&nbsp;Between 3:19 PM and 4:43 PM PST we experienced increased API fault rates and latencies in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "firehose-ap-northeast-2"
+    },
+    {
+      "service_name": "AWS IoT Core (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542848046",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:54 PM PST</span>&nbsp;We are currently investigating increased error rates for AWS IoT Core in the AP-NORTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:09 PM PST</span>&nbsp;Between 3:19 PM and 4:51 PM PST we experienced increased error rates in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "awsiot-ap-northeast-2"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542848776",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:06 PM PST</span>&nbsp;Between 3:15 PM and 4:40 PM PST we experienced increased errors for connections to WorkSpaces in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "workspaces-ap-northeast-2"
+    },
+    {
+      "service_name": "Amazon Redshift (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542849499",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:18 PM PST</span>&nbsp;Between 3:19 PM and 4:56 PM PST we experienced API and S3 connectivity failures in AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "redshift-ap-northeast-2"
+    },
+    {
+      "service_name": "AWS X-Ray (Seoul)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1542849575",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:19 PM PST</span>&nbsp;Between 3:19 PM and 4:43 PM PST we experienced increased error rates for API calls in the AP-NORTHEAST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "xray-ap-northeast-2"
+    },
+    {
+      "service_name": "AWS Billing Console",
+      "summary": "[RESOLVED] Increased Billing Console Error Rates",
+      "date": "1543787631",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:54 PM PST</span>&nbsp;We are investigating errors affecting the Billing Console including the Dashboard and the Bills page.</div><div><span class=\"yellowfg\"> 2:22 PM PST</span>&nbsp;Between 12:28 PM and 2:10 PM PST we experienced increased error rates affecting the Billing Console including the Dashboard and the Bills page. The issue has been resolved and the service is operating normally.</div>",
+      "service": "billingconsole"
+    },
+    {
+      "service_name": "Amazon Elastic File System (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1543880790",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:46 PM PST</span>&nbsp;We are investigating increased error rates for file system creation requests in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 4:13 PM PST</span>&nbsp;We are continuing to experience increased error rates for file system creation requests in the US-EAST-1 Region, and are actively working to resolve the issue.</div><div><span class=\"yellowfg\"> 5:02 PM PST</span>&nbsp;Between 2:40 PM and 4:45 PM PST, we experienced increased error rates for file system creation requests in the US-EAST-1 Region. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "elasticfilesystem-us-east-1"
+    },
+    {
+      "service_name": "AWS Management Console (US-West)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1544570280",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:18 PM PST</span>&nbsp;We are investigating increased error rates for the AWS Management Console in the US-GOV-WEST-1 Region.</div><div><span class=\"yellowfg\"> 3:56 PM PST</span>&nbsp;Between 2:11 PM and 3:41 PM PST we experienced increased error rates for the AWS Management Console in the US-GOV-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "management-console-us-gov-west-1"
+    },
+    {
+      "service_name": "AWS Key Management Service (Sao Paulo)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1544584045",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:07 PM PST</span>&nbsp;We are investigating increased error rates on the KMS CreateKey API in the SA-EAST-1 Region.</div><div><span class=\"yellowfg\"> 7:34 PM PST</span>&nbsp;We have identified the root cause for the increased error rates on the KMS CreateKey API in the SA-EAST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 8:16 PM PST</span>&nbsp;Between 6:23 PM and 8:03 PM PST, we experienced increased error rates on the KMS CreateKey API in the SA-EAST-1 Region. This issue has been resolved and the service is operating normally.</div>",
+      "service": "kms-sa-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Container Registry (N. Virginia)",
+      "summary": "[RESOLVED] Elevated API Error Rates",
+      "date": "1545248645",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:44 AM PST</span>&nbsp;We are investigating increased API error rates for the ECR APIs in the US-EAST-1 Region. </div><div><span class=\"yellowfg\">11:58 AM PST</span>&nbsp;Between 11:14 AM and 11:51 AM PST we experienced increased API error rates for the ECR APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "ecr-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (N. Virginia)",
+      "summary": "[RESOLVED] Increased errors terminating WorkSpaces",
+      "date": "1546532318",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:18 AM PST</span>&nbsp;We are investigating increased errors when terminating WorkSpaces in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 9:23 AM PST</span>&nbsp;Between 6:40 AM and 9:14 AM PST Amazon WorkSpaces experienced increased errors when terminating WorkSpaces in the US-EAST-1 Region. The issue causing increased errors has been resolved and the service is operating normally.</div>",
+      "service": "workspaces-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (London)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1547258341",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:59 PM PST</span>&nbsp;We are investigating network connectivity issues for some instances in a single Available Zone in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\"> 6:29 PM PST</span>&nbsp;We can confirm that some instances have experienced a loss of power in a single Availability Zone in the EU-WEST-2 Region. Some EBS volumes within the affected Availability Zone are experiencing degraded performance. We continue to work on resolving the issue. </div><div><span class=\"yellowfg\"> 7:15 PM PST</span>&nbsp;Between 5:33 PM and 7:06 PM PST some instances experienced connectivity issues within a single Availability Zone in the EU-WEST-2 Region. The affected instances did not lose power but became unreachable due to a loss of power to networking devices within the affected Availability Zone. Some EBS volumes experienced degraded performance during this time period and launches of new EC2 instances and the creation of new EBS volumes experienced increased error rates. The issue has been resolved and the service is operating normally. </div>",
+      "service": "ec2-eu-west-2"
+    },
+    {
+      "service_name": "AWS Lambda (London)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1547258876",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:08 PM PST</span>&nbsp;We are investigating increased error rates and elevated latencies for AWS Lambda requests in the EU-WEST-2 Region. Newly created functions and console editing is also affected.</div><div><span class=\"yellowfg\"> 7:19 PM PST</span>&nbsp;Between 5:33 PM and 7:12 PM PST Lambda experienced elevated error rates and latencies in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally</div>",
+      "service": "lambda-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (London)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1547262903",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:15 PM PST</span>&nbsp;We are investigating connectivity issues affecting some instances in a single Availability Zone in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\"> 7:49 PM PST</span>&nbsp;Beginning at 5:33 PM PST, we experienced connectivity issues affecting some database instances in a single Availability Zone in the EU-WEST-2 Region. Connectivity was restored at 7:11 PM PST, at which point the majority of database instances recovered. A small number of Single-AZ databases remain unavailable and we are continuing to work to recover all affected database instances.</div><div><span class=\"yellowfg\"> 8:08 PM PST</span>&nbsp;Between 5:33 PM PST and 7:11 PM PST, we experienced connectivity issues affecting some database instances in a single Availability Zone in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-eu-west-2"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Elevated Lambda@Edge errors",
+      "date": "1547501684",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:34 PM PST</span>&nbsp;We are investigating elevated Lambda@Edge error rates that may be affecting some customers. CloudFront customers who do not have Lambda@Edge functions are unaffected by this issue. </div><div><span class=\"yellowfg\"> 2:11 PM PST</span>&nbsp;Between 11:40 AM PST and 2:07 PM PST, customers may have experienced elevated Lambda@Edge error rates. CloudFront customers who do not have Lambda@Edge functions were unaffected by this issue. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Ireland)",
+      "summary": "[RESOLVED] Increased API error rates",
+      "date": "1548423741",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:42 AM PST</span>&nbsp;Between 5:03 AM and 5:25 AM PST we experienced increased API error rates and latencies in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Chime",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1548450005",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:00 PM PST</span>&nbsp;We are investigating contact search latency issues in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 1:17 PM PST</span>&nbsp;We are investigating latency in the ability to search contacts, and the inability to add contacts to rooms and calls in the US-EAST-1 Region. Existing users, rooms, and scheduled calls are not impacted.</div><div><span class=\"yellowfg\"> 2:42 PM PST</span>&nbsp;Between 11:38 AM and 2:19 PM PST, we experienced latency in the ability to search contacts, and the inability to add contacts to rooms and calls in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "chime"
+    },
+    {
+      "service_name": "AWS Direct Connect (N. Virginia)",
+      "summary": "[RESOLVED] Increased API errors and latencies",
+      "date": "1548593864",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:57 AM PST</span>&nbsp;We are investigating increased error rates and latencies for AWS Direct Connect APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 5:30 AM PST</span>&nbsp;We continue to investigate increased error rates and latencies for AWS Direct Connect APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:06 AM PST</span>&nbsp;We can confirm increased error rates and latencies for AWS Direct Connect APIs in the US-EAST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 6:31 AM PST</span>&nbsp;Between 4:02 AM and 6:08 AM PST, we experienced increased error rates and latencies for AWS Direct Connect APIs in the US-EAST-1 Region. Connectivity over existing Direct Connect connections was not affected, however, customers may have experienced delays using the Direct Connect console and APIs during this period. The issue has been resolved and the service is operating normally.</div>",
+      "service": "directconnect-us-east-1"
+    },
+    {
+      "service_name": "AWS Marketplace",
+      "summary": "[RESOLVED] Increased Subscription Error Rates ",
+      "date": "1549280664",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:44 AM PST</span>&nbsp;We are investigating increased AWS Marketplace subscription error rates.</div><div><span class=\"yellowfg\"> 4:34 AM PST</span>&nbsp;Between 1:36 AM and 4:07 AM PST we experienced increased AWS Marketplace subscription error rates. The issue has been resolved and the service is operating normally.</div>",
+      "service": "marketplace"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Oregon)",
+      "summary": "[RESOLVED] Small Number of Amazon Aurora Instances Unavailable",
+      "date": "1549679132",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:25 PM PST</span>&nbsp;We are investigating connectivity issues affecting a small number of Amazon Aurora instances in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 7:20 PM PST</span>&nbsp;The majority of database instances that experienced connectivity issues in the US-WEST-2 Region have recovered. We are continuing to work to resolve the instances still experiencing connectivity issues.</div><div><span class=\"yellowfg\"> 8:05 PM PST</span>&nbsp;Between 5:14 PM and 7:40 PM PST, we experienced connectivity issues affecting some Amazon Aurora instances in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-us-west-2"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased Error Rates and Latencies",
+      "date": "1550029704",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:48 PM PST</span>&nbsp;We are investigating increased error rates and latencies for IAM APIs.</div><div><span class=\"yellowfg\"> 8:03 PM PST</span>&nbsp;Between 6:20 PM and 7:49 PM PST, we experienced increased error rates and latencies for IAM APIs. The issue has been resolved and the service is operating normally.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "AWS Elastic Beanstalk (Sydney)",
+      "summary": "[RESOLVED] Increased API Failure Rates",
+      "date": "1550092874",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:21 PM PST</span>&nbsp;We are currently investigating increased error rates to Elastic Beanstalk APIs in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 2:11 PM PST</span>&nbsp;We can confirm increased error rates for the Elastic Beanstalk APIs in the AP-SOUTHEAST-2 Region. We have identified the root cause and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:31 PM PST</span>&nbsp;Between 12:39 PM and 2:12 PM PST we experienced elevated error rates in the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticbeanstalk-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Sydney)",
+      "summary": "[RESOLVED] Increased Create Times and Cluster Unavailability",
+      "date": "1550094163",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:42 PM PST</span>&nbsp;We are investigating increased database create times and cluster unavailability for Amazon Aurora in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 2:09 PM PST</span>&nbsp;We can confirm increased database create times and cluster unavailability for Amazon Aurora in the AP-SOUTHEAST-2 Region. We have identified the root cause and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:49 PM PST</span>&nbsp;We have resolved the issue resulting in increased database create times, and continue to work toward full resolution on Amazon Aurora Cluster Availability.</div><div><span class=\"yellowfg\"> 4:06 PM PST</span>&nbsp;We are beginning to see recovery for some Amazon Aurora Clusters and continue to work toward full resolution.</div><div><span class=\"yellowfg\"> 6:11 PM PST</span>&nbsp;Beginning at 11:54 AM PST some Amazon Aurora clusters experienced increased database create times and cluster unavailability in the AP-SOUTHEAST-2 Region. Elevated create times were resolved at 2:27 PM PST, at which point some existing clusters continued to experience availability issues. As of 5:35 PM PST both issues have been resolved and the service is operating normally. In total, the event impacted a little less than 3% of the Aurora databases in the region.</div>",
+      "service": "rds-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Montreal)",
+      "summary": "[RESOLVED] Increased Create Times and Cluster Unavailability",
+      "date": "1550107156",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:19 PM PST</span>&nbsp;We wanted to provide an update for Amazon Aurora in the CA-CENTRAL-1 Region that we previously communicated to affected customers on their Personal Health Dashboards. Beginning at 11:43 AM PST some Amazon Aurora clusters experienced increased database create times and cluster unavailability in the CA-CENTRAL-1 Region. Elevated create times were resolved at 2:14 PM PST, at which point some existing clusters continued to experience availability issues. As of 4:48 PM PST both issues have been resolved and the service is operating normally.</div>",
+      "service": "rds-ca-central-1"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Increased Change Propagation Time ",
+      "date": "1550635211",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:00 PM PST</span>&nbsp;We are investigating increased propagation times of DNS edits to Route 53 DNS servers. Queries to existing DNS records are not affected by this issue and are being answered normally.</div><div><span class=\"yellowfg\"> 8:19 PM PST</span>&nbsp;We continue to investigate increased propagation times of DNS edits to the Route 53 DNS servers. This issue will also affect provisioning of services such as EFS, ElasticBeanstalk, CloudFormation, and Amazon MQ. Queries to existing DNS records are not affected by this issue. </div><div><span class=\"yellowfg\"> 8:51 PM PST</span>&nbsp;Between 7:34 PM and 8:45 PM PST we experienced increased propagation times of DNS edits. Queries to existing DNS records were not affected by this issue. The issue has been resolved and the service is operating normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Chime",
+      "summary": "[RESOLVED] Availability ",
+      "date": "1550790706",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:11 PM PST</span>&nbsp;We are investigating meeting and chat availability issues.</div><div><span class=\"yellowfg\"> 3:45 PM PST</span>&nbsp;We continue to investigate meeting and chat availability issues. </div><div><span class=\"yellowfg\"> 4:41 PM PST</span>&nbsp;We have identified the root cause of meeting and chat availability issues and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 5:19 PM PST</span>&nbsp;Between 2:51 PM and 5:04 PM PST we experienced meeting and chat availability issues. The issue has been resolved and the service is operating normally.</div>",
+      "service": "chime"
+    },
+    {
+      "service_name": "AWS Certificate Manager (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1551126347",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:25 PM PST</span>&nbsp;We are experiencing increased error rates for AWS Certificate Manager in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">12:59 PM PST</span>&nbsp;We can confirm increased error rates for AWS Certificate Manager in the US-EAST-1 Region. We have identified the root cause and are working toward resolution.</div><div><span class=\"yellowfg\"> 1:50 PM PST</span>&nbsp;Between 11:48 AM and 1:26 PM PST, we experienced increased error rates for AWS Certificate Manager in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "certificatemanager-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Change Propagation Delays",
+      "date": "1551301596",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:06 PM PST</span>&nbsp;Weâ€™re investigating longer than usual propagation times for changes to CloudFront configurations. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\"> 1:30 PM PST</span>&nbsp;Between 10:09 AM and 1:23 PM PST customers may have experienced longer than usual propagation times while making changes to CloudFront configurations. End-user requests for content from edge locations were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Elastic Container Service (Ireland)",
+      "summary": "[RESOLVED] Elevated API Error Rates",
+      "date": "1551383330",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:49 AM PST</span>&nbsp;We are investigating elevated API error rates in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\">12:30 PM PST</span>&nbsp;Between 11:05 AM and 12:05 PM PST we experienced elevated API error rates in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ecs-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased Launch Failures",
+      "date": "1551977827",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:57 AM PST</span>&nbsp;Between 5:40 AM and 8:20 AM PST, new launches of EC2 instances were erroneously disabled in a single Availability Zone within the US-EAST-1 Region. This caused new launches to fail when targeting the affected Availability Zone and also resulted in health checks reporting instances in the affected Availability Zone as impaired. Customers with Auto Scaling Groups configured to replace instances on impaired EC2 health checks may have had instances replaced as a result of this issue. The Availability Zone has been re-enabled for new launches and Auto Scaling has automatically replaced affected instances. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1552347514",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:38 PM PDT</span>&nbsp;We are investigating increased errors when calling WorkSpaces APIs and connecting to WorkSpaces in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 5:39 PM PDT</span>&nbsp;Between 3:35 PM and 4:57 PM PDT we experienced increased API error rates and connection errors to WorkSpaces in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "workspaces-us-east-1"
+    },
+    {
+      "service_name": "Amazon DynamoDB (N. Virginia)",
+      "summary": "[RESOLVED] Latencies in DynamoDB control plane operations",
+      "date": "1552426531",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:35 PM PDT</span>&nbsp;We are currently investigating increased latencies on create, update, and delete table operations with Amazon DynamoDB in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 3:12 PM PDT</span>&nbsp;We have identified the cause of increased latencies on create, update, and delete table operations with Amazon DynamoDB in the US-EAST-1 Region and continue working towards resolution.</div><div><span class=\"yellowfg\"> 3:52 PM PDT</span>&nbsp;We continue to work on resolution for create, update, and delete table operations with Amazon DynamoDB in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 4:05 PM PDT</span>&nbsp;New requests to create, update, and delete tables with Amazon DynamoDB are processing normally in the US-EAST-1 Region. We continue to work towards resolution for backlogged requests.</div><div><span class=\"yellowfg\"> 4:20 PM PDT</span>&nbsp;Between 1:15 PM and 4:14 PM PDT, we experienced increased latencies on create, update, and delete table operations with Amazon DynamoDB in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "dynamodb-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Oregon)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1552507000",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:56 PM PDT</span>&nbsp;We are investigating increased API error rates and launch failures in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 1:13 PM PDT</span>&nbsp;Between 12:29 PM and 12:56 PM PDT, we experienced increased API error rates and launch failures in the US-WEST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "ec2-us-west-2"
+    },
+    {
+      "service_name": "AWS Management Console",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1553118849",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:54 PM PDT</span>&nbsp;We are investigating increased error rates and latencies for the AWS Management Console in the EU-WEST-3 Region.</div><div><span class=\"yellowfg\"> 3:18 PM PDT</span>&nbsp;Between 2:13 PM and 3:08 PM PDT we experienced increased error rates and latencies for the AWS Management Console in the EU-WEST-3 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "management-console"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates and Launch Failures",
+      "date": "1553278711",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:18 AM PDT</span>&nbsp;We are investigating increased API error rates and launch failures in a single Availability Zone in the US-EAST-1 Region. Existing instances are not affected.</div><div><span class=\"yellowfg\">12:06 PM PDT</span>&nbsp;We continue to investigate increased API error rates and launch failures in a single Availability Zone in the US-EAST-1 Region. Existing instances are not affected.</div><div><span class=\"yellowfg\">12:44 PM PDT</span>&nbsp;We continue to investigate increased API error rates and launch failures in a single Availability Zone in the US-EAST-1 Region. Existing instances are not affected.</div><div><span class=\"yellowfg\"> 1:11 PM PDT</span>&nbsp;Between 9:28 AM and 12:52 PM PDT we experienced increased API error rates and launch failures in a single Availability Zone in the US-EAST-1 Region. Existing instances were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Oregon)",
+      "summary": "[RESOLVED] Delayed Metrics",
+      "date": "1553710396",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:14 AM PDT</span>&nbsp;We are investigating increased delays for CloudWatch metrics in the US-WEST-2 Region. CloudWatch alarms may transition into \"INSUFFICIENT_DATA\" state if set on delayed metrics.</div><div><span class=\"yellowfg\">11:33 AM PDT</span>&nbsp;We can confirm increased connection errors and latencies for CloudWatch APIs. Some CloudWatch metrics are delayed. We are actively working to resolve the issue.</div><div><span class=\"yellowfg\">12:30 PM PDT</span>&nbsp;We have identified the root cause of the increased connection errors and latencies for CloudWatch APIs, as well as the CloudWatch metric delays. We continue to work toward recovery.</div><div><span class=\"yellowfg\">12:45 PM PDT</span>&nbsp;We are beginning to see recovery and continue to work toward full recovery. </div><div><span class=\"yellowfg\"> 1:03 PM PDT</span>&nbsp;Between 10:40 AM and 12:44 PM PDT we experienced increased connection errors and latencies for CloudWatch APIs. During this time CloudWatch alarms may have transitioned into \"INSUFFICIENT_DATA\" state if set on delayed metrics. The issue has been resolved and the service is operating normally. </div>",
+      "service": "cloudwatch-us-west-2"
+    },
+    {
+      "service_name": "AWS Certificate Manager (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1553712991",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:57 AM PDT</span>&nbsp;We are investigating increased connection errors and latencies for the ACM APIs and ACM Management Console in the US-WEST-2 Region. </div><div><span class=\"yellowfg\">12:34 PM PDT</span>&nbsp;We have identified the root cause of the increased connection errors and latencies for the ACM APIs and ACM Management Console in the US-WEST-2 Region. We are beginning to see recovery and continue to work toward full resolution.</div><div><span class=\"yellowfg\">12:50 PM PDT</span>&nbsp;Between 10:40 AM and 12:40 PM PDT we experienced increased connection errors and latencies for the ACM APIs and ACM Management Console in the US-WEST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "certificatemanager-us-west-2"
+    },
+    {
+      "service_name": "Auto Scaling (Oregon)",
+      "summary": "[RESOLVED] API Faults and Latencies",
+      "date": "1553715184",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:33 PM PDT</span>&nbsp;We are investigating increased elevated faults and latencies across the DescribePolicies, PutScalingPolicy and RegisterScalableTarget APIs in the US-WEST-2 Region.</div><div><span class=\"yellowfg\">12:54 PM PDT</span>&nbsp;Between 10:40 AM and 12:40 PM PDT we experienced increased elevated faults and latencies across the DescribePolicies, PutScalingPolicy and RegisterScalableTarget APIs in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "autoscaling-us-west-2"
+    },
+    {
+      "service_name": "AWS Lambda (Oregon)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1553757070",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:11 AM PDT</span>&nbsp;We are investigating increased API error rates in the US-WEST-2 Region. </div><div><span class=\"yellowfg\">12:52 AM PDT</span>&nbsp;We have identified the root cause of the issue causing increased API latencies and errors in the US-WEST-2 Region and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:21 AM PDT</span>&nbsp;We continue to see recovery in error rates for AWS Lambda API requests in the US-WEST-2 Region. Some customers may still experience errors in new function creation, updating existing functions and console editing. We continue to work towards full resolution. </div><div><span class=\"yellowfg\"> 2:46 AM PDT</span>&nbsp;Between March 27 11:20 PM and March 28 2:35 AM PDT, AWS Lambda experienced API latencies and errors in the US-WEST-2 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "lambda-us-west-2"
+    },
+    {
+      "service_name": "Amazon API Gateway (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1553757540",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:19 AM PDT</span>&nbsp;We are investigating increased error rates for Lambda integrations and Lambda Authorizers for invokes in the US-WEST-2 Region.</div><div><span class=\"yellowfg\">12:58 AM PDT</span>&nbsp;We have identified the root cause of the issue causing increased error rates for Lambda integrations and Lambda Authorizers for invokes in the US-WEST-2 Region and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:36 AM PDT</span>&nbsp;Between March 27 11:20 PM and March 28 2:23 AM PDT customers using Lambda with API Gateway for Integrations and Authorizers experienced elevated API error rates in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "apigateway-us-west-2"
+    },
+    {
+      "service_name": "AWS Resource Access Manager (Oregon)",
+      "summary": "[RESOLVED] API Latencies and Error Rate",
+      "date": "1553757596",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:20 AM PDT</span>&nbsp;We are investigating increased API latencies and error rates in the US-WEST-2 Region.</div><div><span class=\"yellowfg\">12:55 AM PDT</span>&nbsp;We have identified the root cause of the issue causing increased API latencies and errors in the US-WEST-2 Region and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:36 AM PDT</span>&nbsp;\r\nBetween March 27 11:15 PM and March 28 1:49 AM PDT, we experienced increased API error rates and latencies in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ram-us-west-2"
+    },
+    {
+      "service_name": "AWS Batch (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1553757962",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:26 AM PDT</span>&nbsp;We are investigating increased error rates for API calls in the US-WEST-2 Region. Compute Resource connectivity and running jobs are not affected.</div><div><span class=\"yellowfg\">12:57 AM PDT</span>&nbsp;We have identified the root cause of increased error rates for API calls in the US-WEST-2 Region. Compute Resource connectivity and running jobs are not affected.</div><div><span class=\"yellowfg\"> 2:14 AM PDT</span>&nbsp;We have identified the root cause of increased error rates for API calls in the US-WEST-2 Region impacting new API calls. Compute Resource connectivity and running jobs are not affected. We continue to work towards recovery. </div><div><span class=\"yellowfg\"> 2:39 AM PDT</span>&nbsp;Between March 27 11:21 PM and March 28 2:18 AM PDT, AWS Batch experienced increased error rates for API calls in the US-WEST-2 Region. Compute Resource connectivity and running jobs were not affected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "batch-us-west-2"
+    },
+    {
+      "service_name": "AWS AppSync (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1553758789",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:40 AM PDT</span>&nbsp;We are investigating increased API error rates in the US-WEST-2 Region. </div><div><span class=\"yellowfg\"> 1:14 AM PDT</span>&nbsp;We have identified the root cause of the issue causing increased API error rates in the US-WEST-2 Region and continue to work toward resolution. </div><div><span class=\"yellowfg\"> 2:40 AM PDT</span>&nbsp;Between March 27 11:20 PM and March 28 1:57 AM PDT, we experienced increased API error rates for the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "appsync-us-west-2"
+    },
+    {
+      "service_name": "AWS Certificate Manager (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1553876764",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:26 AM PDT</span>&nbsp;We are investigating increased API error rates in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 9:46 AM PDT</span>&nbsp;We continue to investigate increased API error rates in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">10:18 AM PDT</span>&nbsp;We have identified the root cause of the increased API error rates in the US-EAST-1 Region. We continue to work toward resolution.</div><div><span class=\"yellowfg\">11:28 AM PDT</span>&nbsp;We are beginning to see recovery for the increased API error rates in the US-EAST-1 Region. We continue to work toward full recovery.</div><div><span class=\"yellowfg\">11:53 AM PDT</span>&nbsp;Between 8:41 AM and 11:10 AM PDT we experienced increased API error rates in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "certificatemanager-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Change Propagation Delays",
+      "date": "1553885279",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:48 AM PDT</span>&nbsp;Weâ€™re investigating longer than usual propagation times for changes to CloudFront configurations. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\">12:52 PM PDT</span>&nbsp;We have identified the root cause of the longer than usual propagation times for changes to CloudFront configurations. We continue to work toward resolution. </div><div><span class=\"yellowfg\"> 1:18 PM PDT</span>&nbsp;Between 8:50 AM and 12:59 PM PDT, we experienced longer than usual propagation times for changes to CloudFront configurations. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "AWS Lambda (Ireland)",
+      "summary": "[RESOLVED] Increased Async API Latencies",
+      "date": "1554044749",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:06 AM PDT</span>&nbsp;We are investigating increased Async API latencies in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 8:41 AM PDT</span>&nbsp;We have identified the root cause of increased Async API latencies in the EU-WEST-1 Region and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 9:32 AM PDT</span>&nbsp;Between 6:59 AM and 8:56 AM PDT we experienced increased latencies for the Lambda Async API in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "lambda-eu-west-1"
+    },
+    {
+      "service_name": "AWS IoT Core (Ireland)",
+      "summary": "[RESOLVED] Increased API Errors and Latencies",
+      "date": "1554201606",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:40 AM PDT</span>&nbsp;We are investigating increased API error rates when establishing new connections to AWS IoT Core in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 4:23 AM PDT</span>&nbsp;Between 1:52 AM and 3:35 AM PDT we experienced increased API error rates and latencies in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "awsiot-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Chime",
+      "summary": "[RESOLVED] Authentication Availability",
+      "date": "1554263486",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:51 PM PDT</span>&nbsp;We are investigating availability issues with authenticating using Active Directory in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 9:27 PM PDT</span>&nbsp;Between 6:30 PM and 9:10 PM PDT we experienced increased Active Directory authentication failures in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "chime"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (US-East)",
+      "summary": "[RESOLVED] Network Connectivity ",
+      "date": "1554336479",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:08 PM PDT</span>&nbsp;We are investigating internet connectivity issues in the US-GOV-EAST-1 Region.</div><div><span class=\"yellowfg\"> 5:27 PM PDT</span>&nbsp;We can confirm Internet and EC2 Public IP address connectivity issues for newly launched EC2 instances within the US-GOV-EAST-1 Region. Connectivity for existing instances is not affected.</div><div><span class=\"yellowfg\"> 5:59 PM PDT</span>&nbsp;Between 3:29 PM and 5:50 PM PDT some newly launched instances experienced Internet and EC2 Public IP address connectivity issues in the US-GOV-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-gov-east-1"
+    },
+    {
+      "service_name": "AWS CodeBuild (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates ",
+      "date": "1554742713",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:58 AM PDT</span>&nbsp;We are investigating increased API and Build error rates in the US-EAST-1 Region. </div><div><span class=\"yellowfg\">10:23 AM PDT</span>&nbsp;We have identified the cause of the increased error rates for the CodeBuild Management Console and Build APIs in the US-EAST-1 Region and continue to work towards resolution. </div><div><span class=\"yellowfg\">10:34 AM PDT</span>&nbsp;Between 8:35 AM and 10:05 AM PDT we experienced increased error rates for the CodeBuild Management Console and Build APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "codebuild-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1554964842",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:40 PM PDT</span>&nbsp;We are investigating increased error rates and latencies for the ELB APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">Apr 11, 12:07 AM PDT</span>&nbsp;Between 11:13 PM and 11:54 PM PDT we experienced increased error rates and latencies for the ELB APIs in the US-EAST-1 Region. Connectivity to existing load balancers was not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elb-us-east-1"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Elevated Route 53 API error rates ",
+      "date": "1555178246",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:57 AM PDT</span>&nbsp;We are currently investigating elevated error rates for some Route 53 API calls in the US-EAST-1 Region. There is no impact to answering DNS queries and they continue to work normally.</div><div><span class=\"yellowfg\">11:22 AM PDT</span>&nbsp;Between 10:13 AM and 10:58 AM PDT we experienced intermittent elevated error rates for some Route 53 API calls in the US-EAST-1 Region. There was no impact to answering DNS queries throughout this time. The issue has been resolved and the service is operating normally</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Sao Paulo)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1555527672",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:01 PM PDT</span>&nbsp;We are investigating increased RunInstance API error rates in the SA-EAST-1 Region.</div><div><span class=\"yellowfg\">12:21 PM PDT</span>&nbsp;Between 11:30 AM and 12:09 PM PDT we experienced increased RunInstance API error rates and latencies in the SA-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-sa-east-1"
+    },
+    {
+      "service_name": "AWS Billing Console",
+      "summary": "[RESOLVED] Increased Billing Console Error Rates",
+      "date": "1555578361",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:06 AM PDT</span>&nbsp;We are investigating increased error rates in the Billing Console.</div><div><span class=\"yellowfg\"> 2:56 AM PDT</span>&nbsp;We continue to investigate intermittent availability and increased error rates in the Billing Console.</div><div><span class=\"yellowfg\"> 3:53 AM PDT</span>&nbsp;We continue to investigate intermittent availability and increased error rates in the Billing Console and are working towards resolution. </div><div><span class=\"yellowfg\"> 4:45 AM PDT</span>&nbsp;We have identified the cause of the intermittent availability issues and increased error rates in the Billing Console and continue working towards resolution.</div><div><span class=\"yellowfg\"> 5:17 AM PDT</span>&nbsp;Between 2:06 AM and 5:00 AM PDT we experienced intermittent availability issues and increased error rates in the Billing Console. The issue has been resolved and the service is operating normally.</div>",
+      "service": "billingconsole"
+    },
+    {
+      "service_name": "AWS Management Console (US-East)",
+      "summary": "Increased Console Error Rates",
+      "date": "1556210519",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:20 AM PDT</span>&nbsp;We are investigating increased error rates when loading the AWS Management Console.</div>",
+      "service": "management-console-us-gov-east-1"
+    },
+    {
+      "service_name": "AWS Management Console",
+      "summary": "[RESOLVED] Increased Console Error Rates",
+      "date": "1556210754",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:50 AM PDT</span>&nbsp;We are currently investigating increased errors for loading the AWS Management Console. Alternate link is available at: <a href=\"https://us-west-2.console.aws.amazon.com/ec2/v2/home\">https://us-west-2.console.aws.amazon.com/ec2/v2/home</a></div><div><span class=\"yellowfg\">10:10 AM PDT</span>&nbsp;We can confirm impact to the AWS Management Console in US-EAST-1 specific to the /home link. AWS services are not impacted, and access to service-specific consoles is working normally. Please use alternate link: <a href=\"https://us-west-2.console.aws.amazon.com/ec2/v2/home\">https://us-west-2.console.aws.amazon.com/ec2/v2/home</a></div><div><span class=\"yellowfg\">11:28 AM PDT</span>&nbsp;We continue to work towards resolution in US-EAST-1 for issues specific to the /home Management Console link. AWS services are not impacted, and access to service-specific consoles is working normally. Please use alternate link: <a href=\"https://us-east-1.console.aws.amazon.com/ec2/v2/home\">https://us-east-1.console.aws.amazon.com/ec2/v2/home</a> and select a service from the Services menu above.</div><div><span class=\"yellowfg\">12:18 PM PDT</span>&nbsp;Between 9:11 AM and 12:13 PM PDT we experienced increased error rates for the AWS Management Console in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "management-console"
+    },
+    {
+      "service_name": "AWS Single Sign-On (N. Virginia)",
+      "summary": "[RESOLVED] Single Sign-On",
+      "date": "1556215997",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:13 AM PDT</span>&nbsp;We can confirm impact to the AWS SSO user portal specific to single-sign on to the AWS Management Console. SAML assertions are not impacted but users may be directed to a website unavailable page when authenticating with SAML. Please use alternate link: <a href=\"https://us-west-2.console.aws.amazon.com/ec2/v2/home\">https://us-west-2.console.aws.amazon.com/ec2/v2/home</a> after authenticating. There is no impact to application sign-in.</div><div><span class=\"yellowfg\">11:43 AM PDT</span>&nbsp;We continue to work towards resolution for issues specific to the AWS Management Console. For SSO customers who are seeing an error message while attempting to sign into AWS console through the AWS SSO User Portal, clicking on â€œlogin againâ€ provides access</div><div><span class=\"yellowfg\">12:18 PM PDT</span>&nbsp;Between 9:11 AM and 12:13 PM PDT we experienced increased error rates for the AWS Management Console in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "sso-us-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Storage Service (N. Virginia)",
+      "summary": "[RESOLVED]  Increased Error Rates ",
+      "date": "1556557390",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:03 AM PDT</span>&nbsp;We are investigating increased error rates for Amazon S3 GET and PUT requests in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">10:32 AM PDT</span>&nbsp;We have identified the cause of the increased error rates in the US-EAST-1 Region and are working towards resolution.</div><div><span class=\"yellowfg\">10:42 AM PDT</span>&nbsp;Between 9:18 AM and 10:18 AM PDT we experienced slightly increased GET and PUT error rates for Amazon S3 requests in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "s3-us-standard"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1556576555",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:22 PM PDT</span>&nbsp;We are investigating increased error rates for requests served by certain edge locations in South East Asia.</div><div><span class=\"yellowfg\"> 3:59 PM PDT</span>&nbsp;Between 2:16 PM and 3:43 PM PDT we experienced increased error rates for requests served by edge locations in South East Asia. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Sydney)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1556589414",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:57 PM PDT</span>&nbsp;We are investigating network connectivity issues for some non-Nitro instances in a single Availability Zone in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 7:35 PM PDT</span>&nbsp;We can confirm network connectivity issues for some non-Nitro instances in a single Availability Zone in the AP-SOUTHEAST-2 Region. Connectivity for affected instances can be restored using a stop/start command from the EC2 Management Console or EC2 API. We continue to work towards restoring network connectivity for the affected instances.</div><div><span class=\"yellowfg\"> 8:36 PM PDT</span>&nbsp;We have resolved the network connectivity issue affecting some non-Nitro instances in a single Availability Zone in the AP-SOUTHEAST-2 Region. For instances that are still experiencing connectivity issues, we recommend issuing a reboot or stop/start command from the EC2 Management Console or EC2 API. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Hong Kong)",
+      "summary": "[RESOLVED] EC2 Recursive DNS Resolution Issues",
+      "date": "1556669136",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:06 PM PDT</span>&nbsp;We are investigating DNS resolution issues in a single Availability Zone in the AP-EAST-1 Region.</div><div><span class=\"yellowfg\"> 5:23 PM PDT</span>&nbsp;We are investigating DNS resolution issues, increased API error rates, and error rates for new launches in the AP-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:04 PM PDT</span>&nbsp;Between 4:39 PM and 5:50 PM PDT we experienced DNS resolution issues, increased API error rates, impaired instances, and error rates for new launches in the AP-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-ap-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Queue Service (Ohio)",
+      "summary": "[RESOLVED]  Increased Error Rates ",
+      "date": "1556905071",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:38 AM PDT</span>&nbsp;We are investigating increased error rates in the US-EAST-2 Region.</div><div><span class=\"yellowfg\">11:18 AM PDT</span>&nbsp;Between 10:14 AM and 11:09 AM PDT, we experienced elevated API error rates in the US-EAST-2 Region. We have resolved the issue and the service is operating normally.</div>",
+      "service": "sqs-us-east-2"
+    },
+    {
+      "service_name": "AWS Lambda (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1556906015",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:53 AM PDT</span>&nbsp;We are investigating increased error rates and latency in the US-EAST-2 Region.</div><div><span class=\"yellowfg\">11:54 AM PDT</span>&nbsp;We have identified the cause of increased error rates and latency in the US-EAST-2 Region and are working towards resolution. </div><div><span class=\"yellowfg\">12:28 PM PDT</span>&nbsp;Between 10:14 AM and 12:25 PM PDT, we experienced elevated API error rates in the US-EAST-2 Region. We have resolved the issue and the service is operating normally.</div>",
+      "service": "lambda-us-east-2"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1556906325",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:58 AM PDT</span>&nbsp;We are investigating increased error rates and delays for CloudWatch Logs Insights queries in the US-EAST-2 Region.</div><div><span class=\"yellowfg\">11:15 AM PDT</span>&nbsp;Between 10:14 AM and 11:09 AM PDT, we experienced elevated error rates and delays when running CloudWatch Logs Insights queries in the US-EAST-2 Region. We have resolved the issue and the service is operating normally.</div>",
+      "service": "cloudwatch-us-east-2"
+    },
+    {
+      "service_name": "AWS IoT Core (Ohio)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1556906633",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:04 AM PDT</span>&nbsp;AWS IoT Core is investigating increased error rates and latency in the US-EAST-2 Region.</div><div><span class=\"yellowfg\">11:24 AM PDT</span>&nbsp;Between 10:14 AM and 11:09 AM PDT, we experienced elevated error rates and increased latency when trying to Connect to and Publish Messages on AWS IoT Core in the US-EAST-2 Region. We have resolved the issue and the service is operating normally.</div>",
+      "service": "awsiot-us-east-2"
+    },
+    {
+      "service_name": "AWS Elastic Beanstalk (Ireland)",
+      "summary": "[RESOLVED] Increased API Error Rates ",
+      "date": "1557476843",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:27 AM PDT</span>&nbsp;We are currently investigating increased error rates for the Elastic Beanstalk APIs in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 2:15 AM PDT</span>&nbsp;We have identified the root cause of increased error rates to Elastic Beanstalk APIs in the EU-WEST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 2:27 AM PDT</span>&nbsp;Between 12:43 AM and 1:24 AM PDT, we experienced increased error rates in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticbeanstalk-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Ireland)",
+      "summary": "[RESOLVED] Increased API Error Rates and Connectivity Issues",
+      "date": "1557477953",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:46 AM PDT</span>&nbsp;We are investigating increased API error rates in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 2:14 AM PDT</span>&nbsp;We are investigating increased API error rates and connectivity issues for some Aurora MySQL instances in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 2:34 AM PDT</span>&nbsp;We have identified the root cause of increased API error rates and connectivity issues for some Aurora MySQL instances in the EU-WEST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 4:09 AM PDT</span>&nbsp;Beginning at 12:43 AM PDT we experienced increased API error rates and connectivity issues for some Aurora MySQL instances in the EU-WEST-1 Region. Elevated API error rates were resolved at 1:33 AM PDT, at which point some existing clusters continued to experience connectivity issues. As of 3:50 AM PDT both issues have been resolved and the service is operating normally.</div>",
+      "service": "rds-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Change Propagation Delays & API Errors",
+      "date": "1557512464",
+      "status": 2,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:21 AM PDT</span>&nbsp;We are investigating increased propagation times of DNS edits to public and private Route 53 hosted zones, and increased failures for Delete Hosted Zone, Associate Private Hosted Zone and Disassociate Private Hosted Zone API and Console operations. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">11:28 AM PDT</span>&nbsp;We are investigating increased propagation times of DNS edits to public and private Route 53 hosted zones, and increased failures for Create Hosted Zone, Delete Hosted Zone, Associate Private Hosted Zone and Disassociate Private Hosted Zone API and Console operations. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">12:06 PM PDT</span>&nbsp;We continue to investigate increased propagation times of DNS edits to public and private Route 53 hosted zones, and increased failures for Create Hosted Zone, Delete Hosted Zone, Associate Private Hosted Zone and Disassociate Private Hosted Zone API and Console operations. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">12:35 PM PDT</span>&nbsp;We have identified the root cause and continue to work toward recovery. This may also impact provisioning workflows for other AWS services that use Route 53 for their DNS names. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\"> 2:01 PM PDT</span>&nbsp;DNS updates are being accepted by the Route 53 API and Console, however an error is preventing the updates from being propagated from the Route53 API system to the live DNS servers. We have identified the root cause of this propagation error and are actively working towards resolution. This issue is impacting provisioning workflows for other AWS services that use Route 53 for their DNS names. Queries to DNS records present at the beginning of this issue are not affected and are being answered normally.</div><div><span class=\"yellowfg\"> 4:00 PM PDT</span>&nbsp;Some DNS changes are now propagating to the live DNS servers.  We continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 5:18 PM PDT</span>&nbsp;We are observing steady recovery, with the oldest changes propagating first. We are continuing to work through the backlog of queued changes.</div><div><span class=\"yellowfg\"> 6:30 PM PDT</span>&nbsp;The backlog of queued changes continues to propagate. We have taken steps to accelerate recovery.</div><div><span class=\"yellowfg\"> 7:35 PM PDT</span>&nbsp;We have now propagated more than half of the backlog of queued changes and are continuing to work on the remainder.</div><div><span class=\"yellowfg\"> 8:23 PM PDT</span>&nbsp;We have processed the majority of the backlog of queued changes for Route 53 Public DNS. Private DNS changes are still experiencing propagation delays. Until we have fully recovered, customers may receive an error for the following APIs: CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone. We continue to work towards full recovery.</div><div><span class=\"yellowfg\">10:08 PM PDT</span>&nbsp;As of 8:34 PM PDT, we have resolved the issue resulting in Route 53 Public DNS propagation delays. At this time, Route 53 Private DNS changes are still experiencing propagation delays. Until we have fully recovered, customers will continue to receive errors for the following APIs: CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone.</div><div><span class=\"yellowfg\">11:51 PM PDT</span>&nbsp;We continue to make progress towards restoring propagation for Route 53 Private DNS changes and resolving increased API errors for CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone Route 53 API calls. A majority of our hosts have processed all updates, and we are working to accelerate recovery of the remaining hosts.</div><div><span class=\"yellowfg\">May 11,  1:41 AM PDT</span>&nbsp;We have restored propagation for Route 53 Private DNS changes. We continue to work on resolving increased API errors for CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone Route 53 API calls.</div><div><span class=\"yellowfg\">May 11,  2:39 AM PDT</span>&nbsp;Between May 10 10:50 AM and May 11 2:18 AM PDT we experienced increased change propagation latency and elevated error rates for CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone and DisassociateVPCFromHostedZone calls to the Route 53 API. During this entire duration there were no issues serving DNS queries. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Change Propagation Delays & API Errors",
+      "date": "1557569326",
+      "status": 1,
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">May 10, 11:21 AM PDT</span>&nbsp;We are investigating increased propagation times of DNS edits to public and private Route 53 hosted zones, and increased failures for Delete Hosted Zone, Associate Private Hosted Zone and Disassociate Private Hosted Zone API and Console operations. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">May 10, 11:28 AM PDT</span>&nbsp;We are investigating increased propagation times of DNS edits to public and private Route 53 hosted zones, and increased failures for Create Hosted Zone, Delete Hosted Zone, Associate Private Hosted Zone and Disassociate Private Hosted Zone API and Console operations. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">May 10, 12:06 PM PDT</span>&nbsp;We continue to investigate increased propagation times of DNS edits to public and private Route 53 hosted zones, and increased failures for Create Hosted Zone, Delete Hosted Zone, Associate Private Hosted Zone and Disassociate Private Hosted Zone API and Console operations. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">May 10, 12:35 PM PDT</span>&nbsp;We have identified the root cause and continue to work toward recovery. This may also impact provisioning workflows for other AWS services that use Route 53 for their DNS names. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\">May 10,  2:01 PM PDT</span>&nbsp;DNS updates are being accepted by the Route 53 API and Console, however an error is preventing the updates from being propagated from the Route53 API system to the live DNS servers. We have identified the root cause of this propagation error and are actively working towards resolution. This issue is impacting provisioning workflows for other AWS services that use Route 53 for their DNS names. Queries to DNS records present at the beginning of this issue are not affected and are being answered normally.</div><div><span class=\"yellowfg\">May 10,  4:00 PM PDT</span>&nbsp;Some DNS changes are now propagating to the live DNS servers.  We continue to work towards full recovery.</div><div><span class=\"yellowfg\">May 10,  5:18 PM PDT</span>&nbsp;We are observing steady recovery, with the oldest changes propagating first. We are continuing to work through the backlog of queued changes.</div><div><span class=\"yellowfg\">May 10,  6:30 PM PDT</span>&nbsp;The backlog of queued changes continues to propagate. We have taken steps to accelerate recovery.</div><div><span class=\"yellowfg\">May 10,  7:35 PM PDT</span>&nbsp;We have now propagated more than half of the backlog of queued changes and are continuing to work on the remainder.</div><div><span class=\"yellowfg\">May 10,  8:23 PM PDT</span>&nbsp;We have processed the majority of the backlog of queued changes for Route 53 Public DNS. Private DNS changes are still experiencing propagation delays. Until we have fully recovered, customers may receive an error for the following APIs: CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone. We continue to work towards full recovery.</div><div><span class=\"yellowfg\">May 10, 10:08 PM PDT</span>&nbsp;As of 8:34 PM PDT, we have resolved the issue resulting in Route 53 Public DNS propagation delays. At this time, Route 53 Private DNS changes are still experiencing propagation delays. Until we have fully recovered, customers will continue to receive errors for the following APIs: CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone.</div><div><span class=\"yellowfg\">May 10, 11:51 PM PDT</span>&nbsp;We continue to make progress towards restoring propagation for Route 53 Private DNS changes and resolving increased API errors for CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone Route 53 API calls. A majority of our hosts have processed all updates, and we are working to accelerate recovery of the remaining hosts.</div><div><span class=\"yellowfg\"> 1:41 AM PDT</span>&nbsp;We have restored propagation for Route 53 Private DNS changes. We continue to work on resolving increased API errors for CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone, and DisassociateVPCFromHostedZone Route 53 API calls.</div><div><span class=\"yellowfg\"> 2:39 AM PDT</span>&nbsp;Between May 10 10:50 AM and May 11 2:18 AM PDT we experienced increased change propagation latency and elevated error rates for CreateHostedZone, DeleteHostedZone, AssociateVPCWithHostedZone and DisassociateVPCFromHostedZone calls to the Route 53 API. During this entire duration there were no issues serving DNS queries. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Degraded Call Handling Experience",
+      "date": "1558724798",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:06 PM PDT</span>&nbsp;Between 10:40 AM and 11:04 AM PDT we experienced failures in call handling operations in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Latencies and Management Console Error Rates",
+      "date": "1560790279",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:51 AM PDT</span>&nbsp;We are investigating increased API latencies and increased error rates for the RDS Management Console in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">10:09 AM PDT</span>&nbsp;Between 8:21 AM and 10:01 AM PDT, we experienced increased API latencies and increased error rates for the RDS Management Console in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-us-east-1"
+    },
+    {
+      "service_name": "Amazon Virtual Private Cloud (Singapore)",
+      "summary": "[RESOLVED] AWS Site-to-Site VPN Connectivity Issues",
+      "date": "1561413948",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:05 PM PDT</span>&nbsp;We are investigating network connectivity issues affecting some AWS Site-to-Site VPN customers in the AP-SOUTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 3:24 PM PDT</span>&nbsp;We have identified the root cause of the issue affecting network connectivity for some AWS Site-to-Site VPN connections within the AP-SOUTHEAST-1 Region. Connectivity to and from the Internet, within Amazon VPC, and over DirectConnect is not affected by this issue.</div><div><span class=\"yellowfg\"> 4:11 PM PDT</span>&nbsp;We can confirm network connectivity issues for some AWS Site-to-Site VPN connections within the AP-SOUTHEAST-1 Region and continue to work towards resolution. Connectivity to and from the Internet, within Amazon VPC, and over DirectConnect is not affected by this issue.</div><div><span class=\"yellowfg\"> 4:37 PM PDT</span>&nbsp;We can confirm network connectivity issues for existing AWS Site-to-Site VPN connections within the AP-SOUTHEAST-1 Region and are starting to see recovery. Newly created AWS Site-to-Site VPN connections within the AP-SOUTHEAST-1 Region are not affected by this issue. Connectivity to and from the Internet, within Amazon VPC, and over DirectConnect is not affected by this issue.</div><div><span class=\"yellowfg\"> 5:52 PM PDT</span>&nbsp;We continue to work towards full recovery of the network connectivity issues affecting VPN connections in the AP-SOUTHEAST-1 Region. Connectivity to and from the Internet, within Amazon VPC, and over DirectConnect is not affected by this issue.</div><div><span class=\"yellowfg\"> 7:07 PM PDT</span>&nbsp;We continue to work towards full recovery of the network connectivity issues affecting VPN connections in the AP-SOUTHEAST-1 Region. Connectivity to and from the Internet, within Amazon VPC, and over DirectConnect is not affected by this issue.</div><div><span class=\"yellowfg\"> 9:08 PM PDT</span>&nbsp;Some VPN connections have been restored. We continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 9:54 PM PDT</span>&nbsp;We have now restored connectivity for the majority of the primary tunnels associated with all affected VPN connections in the AP-SOUTHEAST-1 Region. At this stage, VPN connections should no longer be experiencing connectivity issues. We continue to work on restoring connectivity for all secondary tunnels.</div><div><span class=\"yellowfg\">10:35 PM PDT</span>&nbsp;While the majority of VPN tunnels are once again able to establish a connection, route updates are not yet propagating for all affected VPN connections in the AP-SOUTHEAST-1 Region. For affected tunnels, this will result in network connectivity issues which we continue to work on resolving. </div><div><span class=\"yellowfg\">Jun 25,  1:34 AM PDT</span>&nbsp;We continue to make progress in restoring network connectivity for VPN connections in the AP-SOUTHEAST-1 Region. We are also seeing an improvement in route propagation times as we work towards full recovery.</div><div><span class=\"yellowfg\">Jun 25,  6:32 AM PDT</span>&nbsp;We have resolved the connectivity issues affecting VPN connections in the AP-SOUTHEAST-1 Region. Connectivity to and from the Internet, within Amazon VPC, and over DirectConnect was not affected by this issue. The issue has been resolved and the service is operating normally.</div>",
+      "service": "vpc-ap-southeast-1"
+    },
+    {
+      "service_name": "AWS IoT Analytics (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates and Latency",
+      "date": "1561652460",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:32 PM PDT</span>&nbsp;We can confirm increased error rates and latencies in the US-EAST-1 Region. We have identified the root cause and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:33 PM PDT</span>&nbsp;We are seeing significant recovery and continue to work on restoring all operations.</div><div><span class=\"yellowfg\"> 2:45 PM PDT</span>&nbsp;Between 9:21 AM and 2:27 PM PDT we experienced increased API error rates and latencies in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "iotanalytics-us-east-1"
+    },
+    {
+      "service_name": "AWS Glue (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1561655416",
+      "status": "3",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:10 AM PDT</span>&nbsp;We are investigating increased API error rates in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">10:34 AM PDT</span>&nbsp;We can confirm increased API error rates in the US-EAST-1 Region. We have identified the root cause and continue to work toward resolution. </div><div><span class=\"yellowfg\">11:52 AM PDT</span>&nbsp;We are beginning to see intermittent recovery for Glue and continue to work toward full recovery.</div><div><span class=\"yellowfg\"> 1:04 PM PDT</span>&nbsp;We want to give you more information on the issue affecting AWS Glue. Glue Workflow APIs, Orchestration APIs, and ETL jobs that do not require the AWS Glue Data Catalog APIs continue to operate normally. The issue with the Data Catalog APIs started with a software update in the US-EAST-1 Region that completed at 9:21 AM PDT. The software update was immediately rolled back, and we are now working towards stabilizing the Data Catalog API subsystem. We continue to work towards a full recovery.</div><div><span class=\"yellowfg\"> 1:17 PM PDT</span>&nbsp;As we work toward resolution we are temporarily suspending traffic for the Data Catalog APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 2:06 PM PDT</span>&nbsp;We are beginning to work on removing throttles and restoring API availability but are proceeding cautiously.</div><div><span class=\"yellowfg\"> 2:23 PM PDT</span>&nbsp;We are seeing significant recovery and continue to work on restoring all operations.</div><div><span class=\"yellowfg\"> 2:42 PM PDT</span>&nbsp;Between 9:21 AM and 2:06 PM PDT we experienced increased API error rates in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "glue-us-east-1"
+    },
+    {
+      "service_name": "Amazon Athena (N. Virginia)",
+      "summary": "[RESOLVED] Increased Query Failures and Latency",
+      "date": "1561655746",
+      "status": "3",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:15 AM PDT</span>&nbsp;We are investigating increased query failures and latency in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">10:37 AM PDT</span>&nbsp;We can confirm increased query failures and latency in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">11:01 AM PDT</span>&nbsp;We have identified the root cause and continue to work toward resolution.</div><div><span class=\"yellowfg\">11:52 AM PDT</span>&nbsp;We are beginning to see signs of recovery for Athena and continue to work toward full recovery.</div><div><span class=\"yellowfg\">12:32 PM PDT</span>&nbsp;We continue to experience increased error rates, as Athena depends on the Glue Data Catalog APIs. We will be throttling the Athena APIs as we work toward recovery. Customers may receive a \"Rate Exceeded\" error as recovery progresses.</div><div><span class=\"yellowfg\"> 1:35 PM PDT</span>&nbsp;We continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:14 PM PDT</span>&nbsp;We are beginning to work on removing throttles and restoring query availability but are proceeding cautiously.</div><div><span class=\"yellowfg\"> 2:32 PM PDT</span>&nbsp;We are seeing significant recovery and continue to work on restoring all operations.</div><div><span class=\"yellowfg\"> 2:43 PM PDT</span>&nbsp;Between 9:21 AM and 2:36 PM PDT we experienced increased query failures and latency in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "athena-us-east-1"
+    },
+    {
+      "service_name": "Amazon Redshift (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1561658605",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:03 AM PDT</span>&nbsp;We are investigating increased error rates for Redshift Spectrum queries accessing the Glue catalog in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">12:04 PM PDT</span>&nbsp;We can confirm increased error rates for Redshift Spectrum queries accessing the Glue catalog in the US-EAST-1 Region. We have identified the root cause and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 1:09 PM PDT</span>&nbsp;We continue to work toward resolution.</div><div><span class=\"yellowfg\"> 2:33 PM PDT</span>&nbsp;We are seeing significant recovery and continue to work on restoring all operations.</div><div><span class=\"yellowfg\"> 2:45 PM PDT</span>&nbsp;Between 9:21 AM and 2:06 PM PDT we experienced increased error rates for Redshift Spectrum queries accessing the Glue catalog in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "redshift-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (London)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1561864621",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:17 PM PDT</span>&nbsp;We are investigating increased API error rates and latencies in a single Availability Zone in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\"> 9:23 PM PDT</span>&nbsp;We continue to investigate the increased error rates and latencies for the EC2 APIs in the EU-WEST-2 Region. The health of existing EC2 instances is not affected.</div><div><span class=\"yellowfg\">10:00 PM PDT</span>&nbsp;Between 7:40 PM and 9:35 PM PDT we experienced increased API error rates and latencies in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (London)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1561866166",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:42 PM PDT</span>&nbsp;We are investigating increased API error rates and latencies in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\"> 9:51 PM PDT</span>&nbsp;We have identified the root cause of the increase in error rates and latencies for the ELB APIs in the EU-WEST-2 Region and continue to work towards full recovery.</div><div><span class=\"yellowfg\">10:45 PM PDT</span>&nbsp;Between 8:25 PM and 10:15 PM PDT, we experienced increased API error rates and latencies in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elb-eu-west-2"
+    },
+    {
+      "service_name": "Amazon CloudWatch (London)",
+      "summary": "[RESOLVED] Elevated API faults and alarm delays",
+      "date": "1561867337",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:02 PM PDT</span>&nbsp;We are investigating increased faults for CloudWatch alarms APIs and delays in processing some alarms in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\"> 9:55 PM PDT</span>&nbsp;We can confirm an elevated rate of CloudWatch Alarms API faults and delays in processing some alarms in EU-WEST-2 Region and continue to work towards full recovery.</div><div><span class=\"yellowfg\">10:04 PM PDT</span>&nbsp;Between 8:27 PM and 9:55 PM PDT, customers may have experienced elevated alarms API faults and delayed alarms in the EU-WEST-2 Region. We have resolved the issue and the service is operating normally.</div>",
+      "service": "cloudwatch-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Simple Workflow Service (London)",
+      "summary": "[RESOLVED] Elevated error rates for Simple Workflow",
+      "date": "1561871879",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:18 PM PDT</span>&nbsp;We are experiencing elevated API failures for AWS Simple Workflow in the EU-WEST-2 Region and continue to work towards full recovery.</div><div><span class=\"yellowfg\">10:55 PM PDT</span>&nbsp;Between 9:15 PM and 10:30 PM PDT we experienced elevated API failures for AWS Simple Workflow in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "swf-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (US-East)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1562900564",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:02 PM PDT</span>&nbsp;We are investigating increased error rates for the EC2 APIs and new instance launches in the US-GOV-EAST-1 Region. Existing instances are unaffected. </div><div><span class=\"yellowfg\"> 8:35 PM PDT</span>&nbsp;We can confirm increased error rates for the CreateVolume and CreateSnapshot EBS APIs in the US-GOV-EAST-1 Region. This may impact the launching of new EBS backed EC2 instances. Existing instances are unaffected. </div><div><span class=\"yellowfg\"> 9:00 PM PDT</span>&nbsp;Between 7:07 PM and 8:47 PM PDT we experienced increased error rates for the CreateVolume and CreateSnapshot EBS APIs in the US-GOV-EAST-1 Region, which also impacted the launching of new EBS backed EC2 instances. Existing instances were unaffected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-gov-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (London)",
+      "summary": "[RESOLVED] EBS Volumes Degraded Performance",
+      "date": "1563902591",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:23 AM PDT</span>&nbsp;We are investigating degraded performance for EBS volumes in a single Availability Zone in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\">11:11 AM PDT</span>&nbsp;We have determined root cause of the degraded performance for EBS volumes in a single Availability Zone in the EU-WEST-2 Region. The degraded performance has been resolved for some of the affected volumes and we continue to work towards full recovery.</div><div><span class=\"yellowfg\">11:44 AM PDT</span>&nbsp;Between 9:30 AM and 11:37 AM PDT we experienced degraded performance for some EBS volumes in a single Availability Zone in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (London)",
+      "summary": "[RESOLVED] Connectivity Issues",
+      "date": "1563904324",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:52 AM PDT</span>&nbsp;We are investigating connectivity issues affecting some database instances in a single Availability Zone in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\">11:26 AM PDT</span>&nbsp;We have determined root cause for the connectivity issues affecting some database instances in a single Availability Zone in the EU-WEST-2 Region. The connectivity issues have been resolved for some database instances and we continue to work towards full recovery.</div><div><span class=\"yellowfg\">11:51 AM PDT</span>&nbsp;Between 9:30 AM and 11:40 AM PDT we experienced connectivity issues affecting some database instances in a single Availability Zone in the EU-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Increased Call Failures",
+      "date": "1566235755",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:29 AM PDT</span>&nbsp;We are investigating call failures and issues accessing Amazon Connect in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">10:58 AM PDT</span>&nbsp;Call handling has recovered for agents who can access Amazon Connect in the US-EAST-1 Region. We continue to investigate problems accessing the Amazon Connect Console.</div><div><span class=\"yellowfg\">11:46 AM PDT</span>&nbsp;Between 10:02 AM and 11:13 AM PDT, some Amazon Connect users experienced issues logging in or performing actions in the Connect application in the US-EAST-1 Region. Some calls may have failed during this time. The issue has been resolved and the service is operating normally.</div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates and Latencies ",
+      "date": "1566264383",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:26 PM PDT</span>&nbsp;We are investigating increased API error rates and latencies for the EC2 APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:48 PM PDT</span>&nbsp;Between 6:00 PM and 6:41 PM PDT we experienced increased API error rates and latencies for the EC2 APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Tokyo)",
+      "summary": "ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®æŽ¥ç¶šæ€§ã«ã¤ã„ã¦ | Instance Availability",
+      "date": "1566533746",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:18 PM PDT</span>&nbsp;We are investigating connectivity issues affecting some instances in a single Availability Zone in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 9:47 PM PDT</span>&nbsp;We can confirm that some instances are impaired and some EBS volumes are experiencing degraded performance within a single Availability Zone in the AP-NORTHEAST-1 Region. Some EC2 APIs are also experiencing increased error rates and latencies. We are working to resolve the issue.</div><div><span class=\"yellowfg\">10:27 PM PDT</span>&nbsp;We have identified the root cause and are working toward recovery for the instance impairments and degraded EBS volume performance within a single Availability Zone in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\">11:40 PM PDT</span>&nbsp;We are starting to see recovery for instance impairments and degraded EBS volume performance within a single Availability Zone in the AP-NORTHEAST-1 Region. We continue to work towards recovery for all affected instances and EBS volumes.</div><div><span class=\"yellowfg\">Aug 23,  1:54 AM PDT</span>&nbsp;Recovery is in progress for instance impairments and degraded EBS volume performance within a single Availability Zone in the AP-NORTHEAST-1 Region. We continue to work towards recovery for all affected instances and EBS volumes.</div><div><span class=\"yellowfg\">Aug 23,  2:39 AM PDT</span>&nbsp;The majority of impaired EC2 instances and EBS volumes experiencing degraded performance have now recovered. We continue to work on recovery for the remaining EC2 instances and EBS volumes that are affected by this issue. This issue affects EC2 instances and EBS volumes in a single Availability Zone in the AP-NORTHEAST-1 region.</div><div><span class=\"yellowfg\">Aug 23,  4:18 AM PDT</span>&nbsp;æ—¥æœ¬æ™‚é–“ 2019å¹´8æœˆ23æ—¥ 12:36 ã‚ˆã‚Šã€AP-NORTHEAST-1 ã®å˜ä¸€ã®ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã§ã€ä¸€å®šã®å‰²åˆã® EC2 ã‚µãƒ¼ãƒã®ã‚ªãƒ¼ãƒãƒ¼ãƒ’ãƒ¼ãƒˆãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚ã“ã®çµæžœã€å½“è©²ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã® EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹åŠã³ EBS ãƒœãƒªãƒ¥ãƒ¼ãƒ ã®ãƒ‘ãƒ•ã‚©ãƒ¼ãƒžãƒ³ã‚¹ã®åŠ£åŒ–ãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚ã“ã®ã‚ªãƒ¼ãƒãƒ¼ãƒ’ãƒ¼ãƒˆã¯ã€å½±éŸ¿ã‚’å—ã‘ãŸã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ä¸­ã®ä¸€éƒ¨ã®å†—é•·åŒ–ã•ã‚ŒãŸç©ºèª¿è¨­å‚™ã®ç®¡ç†ã‚·ã‚¹ãƒ†ãƒ éšœå®³ãŒåŽŸå› ã§ã™ã€‚æ—¥æœ¬æ™‚é–“ 15:21 ã«å†·å´è£…ç½®ã¯å¾©æ—§ã—ã€å®¤æ¸©ãŒé€šå¸¸çŠ¶æ…‹ã«æˆ»ã‚Šå§‹ã‚ã¾ã—ãŸã€‚æ¸©åº¦ãŒé€šå¸¸çŠ¶æ…‹ã«æˆ»ã£ãŸã“ã¨ã§ã€å½±éŸ¿ã‚’å—ã‘ãŸã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®é›»æºãŒå›žå¾©ã—ã¾ã—ãŸã€‚æ—¥æœ¬æ™‚é–“ 18:30 ã‚ˆã‚Šå¤§éƒ¨åˆ†ã® EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¨ EBS ãƒœãƒªãƒ¥ãƒ¼ãƒ ã¯å›žå¾©ã—ã¾ã—ãŸã€‚ æˆ‘ã€…ã¯æ®‹ã‚Šã® EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¨ EBS ãƒœãƒªãƒ¥ãƒ¼ãƒ ã®å›žå¾©ã«å–ã‚Šçµ„ã‚“ã§ã„ã¾ã™ã€‚å°‘æ•°ã® EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¨ EBS ãƒœãƒªãƒ¥ãƒ¼ãƒ ãŒé›»æºãŒè½ã¡ãŸãƒãƒ¼ãƒ‰ã‚¦ã‚§ã‚¢ ãƒ›ã‚¹ãƒˆä¸Šã«æ®‹ã•ã‚Œã¦ã„ã¾ã™ã€‚æˆ‘ã€…ã¯å½±éŸ¿ã‚’ã†ã‘ãŸå…¨ã¦ã® EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¨ EBS ãƒœãƒªãƒ¥ãƒ¼ãƒ ã®å›žå¾©ã®ãŸã‚ã®ä½œæ¥­ã‚’ç¶™ç¶šã—ã¦ã„ã¾ã™ã€‚ æ—©æœŸå›žå¾©ã®ç‚ºã€å¯èƒ½ãªå ´åˆæ®‹ã•ã‚ŒãŸå½±éŸ¿ã‚’å—ã‘ã¦ã„ã‚‹ EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¨ EBS ãƒœãƒªãƒ¥ãƒ¼ãƒ ã®ãƒªãƒ—ãƒ¬ãƒ¼ã‚¹ã‚’æŽ¨å¥¨ã—ã¾ã™ã€‚ã„ãã¤ã‹ã®å½±éŸ¿ã‚’ã†ã‘ãŸ EC2 ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã¯ãŠå®¢æ§˜å´ã§ã®ä½œæ¥­ãŒå¿…è¦ã«ãªã‚‹å¯èƒ½æ€§ãŒã‚ã‚‹ç‚ºã€ å¾Œã»ã©ãŠå®¢æ§˜å€‹åˆ¥ã«ãŠçŸ¥ã‚‰ã›ã™ã‚‹ã“ã¨ã‚’äºˆå®šã—ã¦ã„ã¾ã™ã€‚<br><br>è©³ç´°ã¯ <a href=\"https://aws.amazon.com/message/56489/\">ã“ã¡ã‚‰</a> ã‚’ã”å‚ç…§ãã ã•ã„ã€‚è¿½åŠ ã®ã”è³ªå•ãŒã‚ã‚‹å ´åˆã¯ã€<a href=\"https://aws.amazon.com/support\">AWS ã‚µãƒãƒ¼ãƒˆ</a>ã¾ã§ã”é€£çµ¡ãã ã•ã„ã€‚ | Beginning at 8:36 PM PDT a small percentage of EC2 servers in a single Availability Zone in the AP-NORTHEAST-1 Region shutdown due to overheating. This resulted in impaired EC2 instances and degraded EBS volume performance for resources in the affected area of the Availability Zone. The overheating was caused by a control system failure that caused multiple, redundant cooling systems to fail in parts of the affected Availability Zone. The chillers were restored at 11:21 PM PDT and temperatures in the affected areas began to return to normal. As temperatures returned to normal, power was restored to the affected instances. By 2:30 AM PDT, the vast majority of instances and volumes had recovered. We have been working to recover the remaining instances and volumes. A small number of remaining instances and volumes are hosted on hardware which was adversely affected by the loss of power. We continue to work to recover all affected instances and volumes. For immediate recovery, we recommend replacing any remaining affected instances or volumes if possible. Some of the affected instances may require action from customers and we will be reaching out to those customers with next steps.<br><br>Additional details are available <a href=\"https://aws.amazon.com/message/56489/\">here</a>. If you have additional questions, please contact <a href=\"https://aws.amazon.com/support\">AWS Support</a>.</div>",
+      "service": "ec2-ap-northeast-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Tokyo)",
+      "summary": "ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®æŽ¥ç¶šæ€§ã«ã¤ã„ã¦ | Instance Availability",
+      "date": "1566537770",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:22 PM PDT</span>&nbsp;AWSã§ã¯ã€ç¾åœ¨ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®1ã¤ã®ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã§ç™ºç”Ÿã—ã¦ã„ã‚‹ã€è¤‡æ•°ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã«å¯¾ã™ã‚‹æŽ¥ç¶šæ€§ã®å•é¡Œã«ã¤ã„ã¦èª¿æŸ»ã‚’é€²ã‚ã¦ãŠã‚Šã¾ã™ã€‚| We are investigating connectivity issues affecting some instances in a single Availability Zone in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\">11:25 PM PDT</span>&nbsp;AWSã§ã¯ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®1ã¤ã®ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã§ç™ºç”Ÿã—ã¦ã„ã‚‹ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®æŽ¥ç¶šæ€§ã®å•é¡Œã«ã¤ã„ã¦åŽŸå› ã‚’ç‰¹å®šã—ã€ç¾åœ¨å¾©æ—§ã«å‘ã‘ã¦å¯¾å¿œã‚’é€²ã‚ã¦ãŠã‚Šã¾ã™ã€‚| We have identified the root cause of instance connectivity issues within a single Availability Zone in the AP-NORTHEAST-1 Region and are working toward recovery.</div><div><span class=\"yellowfg\">Aug 23, 12:01 AM PDT</span>&nbsp;AWSã§ã¯ã€ç¾åœ¨ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®1ã¤ã®ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã§ç™ºç”Ÿã—ã¦ã„ã‚‹ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®æŽ¥ç¶šæ€§ã®å•é¡Œã¤ã„ã¦ã€å¾©æ—§ã‚’é–‹å§‹ã—ã¦ãŠã‚Šã¾ã™ã€‚å½±éŸ¿ã‚’å—ã‘ã¦ã„ã‚‹å…¨ã¦ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®å¾©æ—§ã«å‘ã‘ã€å¯¾å¿œã‚’ç¶™ç¶šã„ãŸã—ã¾ã™ã€‚| We are starting to see recovery for instance connectivity issues within a single Availability Zone in the AP-NORTHEAST-1 Region. We continue to work towards recovery for all affected instances.</div><div><span class=\"yellowfg\">Aug 23,  2:16 AM PDT</span>&nbsp;AWSã§ã¯ã€ç¾åœ¨ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®1ã¤ã®ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã§æŽ¥ç¶šæ€§ã®å•é¡ŒãŒç”Ÿã˜ã¦ã„ã‚‹å…¨ã¦ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®å¾©æ—§ã«å‘ã‘ã€å¯¾å¿œã‚’é€²ã‚ã¦ãŠã‚Šã¾ã™ã€‚| We continue to see recovery for instance connectivity issues within a single Availability Zone in the AP-NORTHEAST-1 Region and are working towards recovery for all affected instances.</div><div><span class=\"yellowfg\">Aug 23,  6:19 AM PDT</span>&nbsp;æ—¥æœ¬æ™‚é–“ 2019å¹´8æœˆ23æ—¥ 12:36 ã‹ã‚‰ 22:05 ã«ã‹ã‘ã¦ã€æ±äº¬ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®å˜ä¸€ã®ã‚¢ãƒ™ã‚¤ãƒ©ãƒ“ãƒªãƒ†ã‚£ã‚¾ãƒ¼ãƒ³ã§ä¸€éƒ¨ã® RDS ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã«æŽ¥ç¶šæ€§ã®å•é¡ŒãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚ç¾åœ¨ã€ã“ã®å•é¡Œã¯è§£æ¶ˆã—ã¦ãŠã‚Šã€ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ç¨¼åƒã—ã¦ãŠã‚Šã¾ã™ã€‚<br><br>è©³ç´°ã¯ <a href=\"https://aws.amazon.com/message/56489/\">ã“ã¡ã‚‰</a> ã‚’ã”å‚ç…§ãã ã•ã„ã€‚è¿½åŠ ã®ã”è³ªå•ãŒã‚ã‚‹å ´åˆã¯ã€<a href=\"https://aws.amazon.com/support\">AWS ã‚µãƒãƒ¼ãƒˆ</a>ã¾ã§ã”é€£çµ¡ãã ã•ã„ã€‚| Between August 22 8:36 PM and August 23 6:05 AM PDT, some RDS instances experienced connectivity issues within a single Availability Zone in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally. <br><br>Additional details are available <a href=\"https://aws.amazon.com/message/56489/\">here</a>. If you have additional questions, please contact <a href=\"https://aws.amazon.com/support\">AWS Support</a>.</div>",
+      "service": "rds-ap-northeast-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Instances Unavailable",
+      "date": "1567257765",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:22 AM PDT</span>&nbsp;We are investigating connectivity issues affecting some instances in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:54 AM PDT</span>&nbsp;We can confirm that some instances are impaired and some EBS volumes are experiencing degraded performance within a single Availability Zone in the US-EAST-1 Region. Some EC2 APIs are also experiencing increased error rates and latencies. We are working to resolve the issue.</div><div><span class=\"yellowfg\"> 7:37 AM PDT</span>&nbsp;We can confirm that some instances are impaired and some EBS volumes are experiencing degraded performance within a single Availability Zone in the US-EAST-1 Region. We are investigating increased error rates for new launches within the same Availability Zone. We are working to resolve the issue.</div><div><span class=\"yellowfg\"> 8:06 AM PDT</span>&nbsp;We are starting to see recovery for instance impairments and degraded EBS volume performance within a single Availability Zone in the US-EAST-1 Region. We are also starting to see recovery of EC2 APIs. We continue to work towards recovery for all affected EC2 instances and EBS volumes.</div><div><span class=\"yellowfg\"> 9:04 AM PDT</span>&nbsp;Recovery is in progress for instance impairments and degraded EBS volume performance within a single Availability Zone in the US-EAST-1 Region. We continue to work towards recovery for all remaining affected instances and EBS volumes. </div><div><span class=\"yellowfg\">10:47 AM PDT</span>&nbsp;We want to give you more information on progress at this point, and what we know about the event. At 4:33 AM PDT one of 10 datacenters in one of the 6 Availability Zones in the US-EAST-1 Region saw a failure of utility power. Backup generators came online immediately, but for reasons we are still investigating, began quickly failing at around 6:00 AM PDT. This resulted in 7.5% of all instances in that Availability Zone failing by 6:10 AM PDT. Over the last few hours we have recovered most instances but still have 1.5% of the instances in that Availability Zone remaining to be recovered. Similar impact existed to EBS and we continue to recover volumes within EBS. New instance launches in this zone continue to work without issue.</div><div><span class=\"yellowfg\"> 1:30 PM PDT</span>&nbsp;At 4:33 AM PDT one of ten data centers in one of the six Availability Zones in the US-EAST-1 Region saw a failure of utility power. Our backup generators came online immediately but began failing at around 6:00 AM PDT. This impacted 7.5% of EC2 instances and EBS volumes in the Availability Zone. Power was fully restored to the impacted data center at 7:45 AM PDT. By 10:45 AM PDT, all but 1% of instances had been recovered, and by 12:30 PM PDT only 0.5% of instances remained impaired. Since the beginning of the impact, we have been working to recover the remaining instances and volumes. A small number of remaining instances and volumes are hosted on hardware which was adversely affected by the loss of power. We continue to work to recover all affected instances and volumes and will be communicating to the remaining impacted customers via the Personal Health Dashboard. For immediate recovery, we recommend replacing any remaining affected instances or volumes if possible. </div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (N. Virginia)",
+      "summary": "[RESOLVED] Connectivity Issues",
+      "date": "1567259752",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:55 AM PDT</span>&nbsp;We are investigating connectivity issues in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 7:50 AM PDT</span>&nbsp;We can confirm that some WorkSpaces instances are impaired within a single Availability Zone in the US-EAST-1 Region. We are working to resolve the issue.</div><div><span class=\"yellowfg\"> 8:33 AM PDT</span>&nbsp;We are starting to see recovery of WorkSpaces instance impairments within a single Availability Zone in the US-EAST-1 Region. We continue to work towards recovery for all affected WorkSpaces instances.</div><div><span class=\"yellowfg\"> 2:02 PM PDT</span>&nbsp;Beginning at 6:15 AM PDT, we experienced connectivity issues affecting some WorkSpaces in a single Availability Zone in the US-EAST-1 Region. By 12:30 PM, the majority of the impaired WorkSpaces had been recovered. A small number of the impaired WorkSpaces were hosted on hardware which may have been adversely affected by the loss of power. We continue to work to recover all affected WorkSpaces. Some of the remaining impacted WorkSpaces may require action from customers and we will be communicating to the remaining impacted customers via the Personal Health Dashboard. </div>",
+      "service": "workspaces-us-east-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (N. Virginia)",
+      "summary": "[RESOLVED] Connectivity Issues",
+      "date": "1567260966",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:16 AM PDT</span>&nbsp;We are investigating connectivity issues affecting some single-AZ RDS instances in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 8:25 AM PDT</span>&nbsp;We are starting to see recovery for connectivity issues impacting some single-AZ instances in a single Availability Zone in the US-EAST-1 Region. We continue to work towards recovery for all impacted instances. </div><div><span class=\"yellowfg\"> 2:15 PM PDT</span>&nbsp;Beginning at 5:40 AM PDT, some RDS single-AZ instances experienced connectivity issues within a single Availability Zone in the US-EAST-1 Region. By 11:55 AM, 1% of instances in the affected AZ were still experiencing connectivity issues. We continue to work to recover all affected instances and volumes and will be communicating to the remaining impacted customers via the Personal Health Dashboard. For customers who need immediate recovery, we recommend performing a <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIT.html\">point in time</a> or <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RestoreFromSnapshot.html\">snapshot recovery</a> of your DB instance from the AWS Management Console or RDS APIs.</div>",
+      "service": "rds-us-east-1"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (Ireland)",
+      "summary": "[RESOLVED] WorkSpaces Launch Errors",
+      "date": "1568280002",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:20 AM PDT</span>&nbsp;We are investigating increased errors when launching new WorkSpaces in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 2:49 AM PDT</span>&nbsp;Between September 11 6:35 PM and September 12 2:24 AM PDT we experienced increased errors when launching new WorkSpaces in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "workspaces-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates and Latencies",
+      "date": "1568389951",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 8:52 AM PDT</span>&nbsp;Between 7:49AM PDT and 8:27AM PDT EC2 experienced elevated API errors for instance related APIs in a single Availability Zone in the US-EAST-1 region. Existing instances were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates and Latencies",
+      "date": "1568742586",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:49 AM PDT</span>&nbsp;Between 9:45 AM and 10:25 AM PDT we experienced increased API error rates and latencies in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Increased Invalidation Error Rates",
+      "date": "1568887640",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:07 AM PDT</span>&nbsp;We are investigating elevated error rates for content invalidation. Some customers may also receive \"Rate exceeded\" exceptions when attempting to invalidate content. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\"> 3:36 AM PDT</span>&nbsp;Between September 18 10:58 PM and September 19 2:44 AM PDT, we experienced increased API error rates impacting CreateInvalidation API. Some customers may have also received \"Rate exceeded\" exceptions when attempting to invalidate content. End-user requests for content were not affected by this issue, and content from our edge locations were not affected and continue to be served normally. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1569184140",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:32 PM PDT</span>&nbsp;We are investigating increased API error rates in the US-EAST-1 Region</div><div><span class=\"yellowfg\"> 3:34 PM PDT</span>&nbsp;We continue to investigate increased error rates with Console and API calls in the US-EAST-1 Region. Connectivity to currently running instances is not affected. </div><div><span class=\"yellowfg\"> 4:39 PM PDT</span>&nbsp;We continue to see increased error rates with Console and API calls in the US-EAST-1 Region and are working towards recovery. Connectivity to currently running instances is not affected.</div><div><span class=\"yellowfg\"> 7:07 PM PDT</span>&nbsp;We have identified the issue causing increased error rates with RDS Console and API calls in the US-EAST-1 Region and are working towards recovery.</div><div><span class=\"yellowfg\"> 8:06 PM PDT</span>&nbsp;Between 1:29 PM and 7:34 PM PDT we experienced increased error rates for the RDS Management Console and API calls. The issue is resolved and the service is operating normally.</div>",
+      "service": "rds-us-east-1"
+    },
+    {
+      "service_name": "AWS Management Console",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1569187417",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:23 PM PDT</span>&nbsp;We are investigating increased error rates in the US-EAST-1 Region for RDS and Autoscaling Management Consoles.</div><div><span class=\"yellowfg\"> 3:33 PM PDT</span>&nbsp;We are continuing to investigate elevated error rates with the RDS Management Console in the US-EAST-1 Region, Autoscaling Console has recovered and is operating normally.</div><div><span class=\"yellowfg\"> 4:43 PM PDT</span>&nbsp;We are continuing to investigate elevated error rates with the RDS Management Console in the US-EAST-1 Region. All other consoles are operating normally.</div><div><span class=\"yellowfg\"> 6:32 PM PDT</span>&nbsp;We continue to see increased error rates with the RDS Console in the US-EAST-1 Region and are working towards recovery</div><div><span class=\"yellowfg\"> 7:10 PM PDT</span>&nbsp;We have identified the issue causing increased error rates with the RDS Management Console in the US-EAST-1 Region and are working towards recovery. </div><div><span class=\"yellowfg\"> 8:12 PM PDT</span>&nbsp;Between 1:29 PM and 7:34 PM PDT, we experienced increased error rates when working with the RDS Management Console in the US-EAST-1 region. The issue has been resolved and the Management Console is operating normally.</div>",
+      "service": "management-console"
+    },
+    {
+      "service_name": "Amazon API Gateway (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1569529335",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:22 PM PDT</span>&nbsp;We are investigating increased error rates for API Management calls via the console, CLI, and CloudFormation in the US-EAST-1 Region. There is no impact to invocations of deployed APIs.</div><div><span class=\"yellowfg\"> 2:04 PM PDT</span>&nbsp;Between 12:22 PM and 1:47 PM PDT we experienced increased error rates for API Management calls via the console, CLI, and CloudFormation in the US-EAST-1 Region. There was no impact to invocations of deployed APIs. The issue is resolved, and the service is operating normally.</div>",
+      "service": "apigateway-us-east-1"
+    },
+    {
+      "service_name": "AWS Internet Connectivity (Singapore)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1569965515",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:31 PM PDT</span>&nbsp;We are investigating network connectivity issues for some AWS services in the AP-SOUTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 3:07 PM PDT</span>&nbsp; Between 1:51 PM  and 2:41 PM PDT we experienced network connectivity issues for some AWS APIs in the AP-SOUTHEAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "internetconnectivity-ap-southeast-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Singapore)",
+      "summary": "[RESOLVED] Network Connectivity and API Error Rates",
+      "date": "1569966223",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:43 PM PDT</span>&nbsp;We are investigating connectivity issues and increased API error rates in the AP-SOUTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 3:17 PM PDT</span>&nbsp;Between 1:51 PM and 2:41 PM PDT we experienced API error rates for the EC2 APIs and the EC2 Management Console in the AP-SOUTHEAST-1 Region. Connectivity to EC2 instances was not impacted during this event. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-ap-southeast-1"
+    },
+    {
+      "service_name": "AWS Batch (Ireland)",
+      "summary": "[RESOLVED] Increased API error rates and latencies",
+      "date": "1570041989",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:46 AM PDT</span>&nbsp;We are investigating increased API error rates and latencies for the AWS Batch APIs in the EU-WEST-1 Region. Compute Resource connectivity and running jobs are not affected. </div><div><span class=\"yellowfg\">12:15 PM PDT</span>&nbsp;Between 10:35 AM and 11:59 AM PDT we experienced increased error rates and latencies for all AWS Batch APIs in the EU-WEST-1 Region. Compute Resource connectivity and running jobs were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "batch-eu-west-1"
+    },
+    {
+      "service_name": "AWS IoT Core (Ireland)",
+      "summary": "[RESOLVED] Increased API error rates",
+      "date": "1570042403",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:53 AM PDT</span>&nbsp;We are investigating increased API error rates for AWS IoT Core APIs for managing Identities, Policies, Things and Rules in the EU-WEST-1 region. Device connections, messaging and rules executions are not impacted.</div><div><span class=\"yellowfg\">12:18 PM PDT</span>&nbsp;Between 10:52 AM and 11:57 AM PDT, we experienced elevated API error rates for managing Identities, Policies, Things and Rules in the EU-WEST-1 region. We have resolved the issue and the service is operating normally. </div>",
+      "service": "awsiot-eu-west-1"
+    },
+    {
+      "service_name": "Amazon API Gateway (Ireland)",
+      "summary": "[RESOLVED] Increase API error rates",
+      "date": "1570043240",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:07 PM PDT</span>&nbsp;We are investigating increased error rates for API invokes in the EU-WEST-1 Region.</div><div><span class=\"yellowfg\"> 1:19 PM PDT</span>&nbsp;We have identified the root cause of the issue causing increased error rates in the EU-WEST-1 Region and are working on a resolution.</div><div><span class=\"yellowfg\"> 1:32 PM PDT</span>&nbsp;Between 10:23 AM and 1:11 PM PDT we experienced increased error rates in the EU-WEST-1 Region. The issue is resolved and the service is operating normally.</div>",
+      "service": "apigateway-eu-west-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (N. Virginia)",
+      "summary": "[RESOLVED] Elevated Error Rates",
+      "date": "1570238568",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:22 PM PDT</span>&nbsp;We are investigating elevated rate of API faults and delays in processing some alarms in the US-EAST-1 Region. We are actively working to resolve the issue.</div><div><span class=\"yellowfg\"> 6:42 PM PDT</span>&nbsp;We can confirm that scheduled events are not being delivered via CloudWatch Events in the US-EAST-1 Region. We are actively working to resolve the issue. </div><div><span class=\"yellowfg\"> 6:49 PM PDT</span>&nbsp;We can confirm that scheduled events are not being delivered via CloudWatch Events in the US-EAST-1 Region. AWS Lambda functions that are invoked in response to CloudWatch events may not be getting invoked successfully. We are actively working to resolve the issue.</div><div><span class=\"yellowfg\"> 7:34 PM PDT</span>&nbsp;We have identified the root cause of the errors in scheduled event creation. We can confirm that AWS Lambda functions that are invoked in response to scheduled CloudWatch events are not getting invoked successfully. We are actively working towards recovery.</div><div><span class=\"yellowfg\"> 8:49 PM PDT</span>&nbsp;We are starting to see recovery of scheduled CloudWatch event delivery. We are also starting to see recovery of AWS Lambda functions that were set up to be invoked from scheduled CloudWatch events. </div><div><span class=\"yellowfg\"> 9:48 PM PDT</span>&nbsp;Starting at 5:27 PM PDT, there were delays delivering scheduled CloudWatch events. Recovery began at 7:31 PM PDT, and by 9:28 PM PDT the backlog of all previously scheduled CloudWatch events was successfully delivered. AWS Lambda functions that were configured to be triggered from scheduled CloudWatch events are now being invoked normally. During this entire duration all other kinds of CloudWatch events and other Lambda function invocations continued to operate normally. All issues are fully resolved and the services are operating normally.</div>",
+      "service": "cloudwatch-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Ireland)",
+      "summary": "[RESOLVED] Elevated Error Rates ",
+      "date": "1570239838",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:43 PM PDT</span>&nbsp;We can confirm that scheduled events are not being delivered via CloudWatch Events in the EU-WEST-1 Region. AWS Lambda functions that are invoked in response to CloudWatch events may not be getting invoked successfully. We are actively working to resolve the issue.</div><div><span class=\"yellowfg\"> 7:36 PM PDT</span>&nbsp;We have identified the root cause of the errors in scheduled event creation. We can confirm that AWS Lambda functions that are invoked in response to scheduled CloudWatch events are not getting invoked successfully. We are actively working towards recovery. </div><div><span class=\"yellowfg\"> 8:46 PM PDT</span>&nbsp;We are starting to see recovery of scheduled CloudWatch event delivery. We are also starting to see recovery of AWS Lambda functions that were set up to be invoked from scheduled CloudWatch events. </div><div><span class=\"yellowfg\"> 9:44 PM PDT</span>&nbsp;Starting at 5:27 PM PDT, there were delays delivering scheduled CloudWatch events. Recovery began at 8:55 PM PDT, and we are currently working to deliver the backlog of all previously scheduled CloudWatch events. All other kinds of CloudWatch events and other Lambda function invocations continue to operate normally.</div><div><span class=\"yellowfg\">10:19 PM PDT</span>&nbsp;Starting at 5:27 PM PDT, there were delays delivering scheduled CloudWatch events. Recovery began at 8:55 PM PDT, and by 10:15 PM PDT the backlog of all previously scheduled CloudWatch events was successfully delivered. AWS Lambda functions that were configured to be triggered from scheduled CloudWatch events are now being invoked normally. During this entire duration all other kinds of CloudWatch events and other Lambda function invocations continued to operate normally. All issues are fully resolved and the services are operating normally.</div>",
+      "service": "cloudwatch-eu-west-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Oregon)",
+      "summary": "[RESOLVED] Elevated Error Rates",
+      "date": "1570239912",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:45 PM PDT</span>&nbsp;We can confirm that scheduled events are not being delivered via CloudWatch Events in the US-WEST-2 Region. We are actively working to resolve the issue. </div><div><span class=\"yellowfg\"> 6:51 PM PDT</span>&nbsp;We can confirm that scheduled events are not being delivered via CloudWatch Events in the US-WEST-2. AWS Lambda functions that are invoked in response to CloudWatch events may not be getting invoked successfully. We are actively working to resolve the issue.\n\n</div><div><span class=\"yellowfg\"> 7:35 PM PDT</span>&nbsp;We have identified the root cause of the errors in scheduled event creation. We can confirm that AWS Lambda functions that are invoked in response to scheduled CloudWatch events are not getting invoked successfully. We are actively working towards recovery. </div><div><span class=\"yellowfg\"> 8:46 PM PDT</span>&nbsp;We are starting to see recovery of scheduled CloudWatch event delivery. We are also starting to see recovery of AWS Lambda functions that were set up to be invoked from scheduled CloudWatch events. </div><div><span class=\"yellowfg\"> 9:37 PM PDT</span>&nbsp;Starting at 5:27 PM PDT, there were delays delivering scheduled CloudWatch events. Recovery began at 7:36 PM PDT, and by 9:22 PM PDT the backlog of all previously scheduled CloudWatch events was successfully delivered. AWS Lambda functions that were configured to be triggered from scheduled CloudWatch events are now being invoked normally. During this entire duration all other kinds of CloudWatch events and other Lambda function invocations continued to operate normally. All issues are fully resolved and the services are operating normally.</div>",
+      "service": "cloudwatch-us-west-2"
+    },
+    {
+      "service_name": "AWS Backup (Frankfurt)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1570493040",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:00 PM PDT</span>&nbsp;We are investigating increased API error rates in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\"> 7:36 PM PDT</span>&nbsp;We continue to investigate increased API error rates in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\"> 9:32 PM PDT</span>&nbsp;We have identified the cause of the increased API error rates in the EU-CENTRAL-1 Region and continue working towards resolution.</div><div><span class=\"yellowfg\">10:09 PM PDT</span>&nbsp;Between 5:04 PM and 9:17 PM PDT we experienced increased API error rates in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "backup-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Simple Storage Service (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates for Bucket Operations",
+      "date": "1570551545",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:19 AM PDT</span>&nbsp;We have identified the cause of the increased error rates for customers creating and managing Amazon S3 buckets and are working towards resolution. Only a small subset of requests are affected and retries are working.</div><div><span class=\"yellowfg\"> 9:30 AM PDT</span>&nbsp;Between 7:54 AM and 9:18 AM PDT, S3 customers saw elevated errors and latency for a subset of API requests to create and manage Amazon S3 buckets. The issue has been resolved and the service is operating normally.</div>",
+      "service": "s3-us-standard"
+    },
+    {
+      "service_name": "AWS Backup (Frankfurt)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1570579440",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">Oct 7,  7:00 PM PDT</span>&nbsp;We are investigating increased API error rates in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\">Oct 7,  7:36 PM PDT</span>&nbsp;We continue to investigate increased API error rates in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\">Oct 7,  9:32 PM PDT</span>&nbsp;We have identified the cause of the increased API error rates in the EU-CENTRAL-1 Region and continue working towards resolution.</div><div><span class=\"yellowfg\">Oct 7, 10:09 PM PDT</span>&nbsp;Between 5:04 PM and 9:17 PM PDT we experienced increased API error rates in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "backup-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Increased API error rates",
+      "date": "1571588700",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:16 AM PDT</span>&nbsp;We are investigating increased errors when making changes to some hosted zones, and creation of new hosted zones using the Route 53 API. DNS queries are not affected by this issue, which are all being answered as normal.</div><div><span class=\"yellowfg\">10:46 AM PDT</span>&nbsp;We are continuing to investigate elevated API errors when making changes to some hosted zones, and creation of new hosted zones using the Route 53 API. DNS queries are not affected by this issue, which are all being answered normally.</div><div><span class=\"yellowfg\">11:26 AM PDT</span>&nbsp;We have identified root cause and are working towards recovery of elevated error rates using the Route 53 API. DNS queries are not affected by this issue, which are all being answered normally.</div><div><span class=\"yellowfg\">11:33 AM PDT</span>&nbsp;Between 9:25 AM and 11:30 AM PDT, we experienced increased errors when making changes to some hosted zones, and creating new hosted zones using the Route 53 API and Console. The issue has been recovered, and all services are operating normally. DNS queries were not affected by this issue, which were all answered normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Increased API error rates",
+      "date": "1571591808",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:16 AM PDT</span>&nbsp;We are investigating increased errors when making changes to some hosted zones, and creation of new hosted zones using the Route 53 API. DNS queries are not affected by this issue, which are all being answered as normal.</div><div><span class=\"yellowfg\">10:46 AM PDT</span>&nbsp;We are continuing to investigate elevated API errors when making changes to some hosted zones, and creation of new hosted zones using the Route 53 API. DNS queries are not affected by this issue, which are all being answered normally.</div><div><span class=\"yellowfg\">11:26 AM PDT</span>&nbsp;We have identified root cause and are working towards recovery of elevated error rates using the Route 53 API. DNS queries are not affected by this issue, which are all being answered normally.</div><div><span class=\"yellowfg\">11:33 AM PDT</span>&nbsp;Between 9:25 AM and 11:30 AM PDT, we experienced increased errors when making changes to some hosted zones, and creating new hosted zones using the Route 53 API and Console. The issue has been recovered, and all services are operating normally. DNS queries were not affected by this issue, which were all answered normally.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Further information regarding DNS resolution",
+      "date": "1571877848",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:44 PM PDT</span>&nbsp;On October 22, 2019, we detected and then mitigated a DDoS (Distributed Denial of Service) attack against Route 53. Due to the way that DNS queries are processed, this attack was first experienced by many other DNS server operators as the queries made their way through DNS resolvers on the internet to Route 53. The attack targeted specific DNS names and paths, notably those used to access the global names for S3 buckets.\n\nBecause this attack was widely distributed, a small number of ISPs operating affected DNS resolvers implemented mitigation strategies of their own in an attempt to control the traffic. This is causing DNS lookups through these resolvers for a small number of AWS names to fail. We are doing our best to identify and contact these operators, as quickly as possible, and working with them to enhance their mitigations so that they do not cause impact to valid requests. If you are experiencing issues, please contact us so we can work with your operator to help resolve.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Degraded Call Handling",
+      "date": "1572019433",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:03 AM PDT</span>&nbsp;We are investigating degraded call handling by agents using the Amazon Connect softphone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 9:48 AM PDT</span>&nbsp;Between 8:17 AM and 9:30 AM PDT we experienced degraded call handling by agents using the softphone in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.\n</div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "Amazon Kinesis Data Streams (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1572377331",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:28 PM PDT</span>&nbsp;We are investigating increased Create, Update, and Delete Stream API error rates for Amazon Kinesis Data Streams in the US-EAST-1 Region. </div><div><span class=\"yellowfg\"> 1:06 PM PDT</span>&nbsp;Between 10:45 AM and 12:52 PM PDT, we experienced increased error rates for Create, Update, and Delete Stream API operations for Amazon Kinesis Data Streams in the US-EAST-1 Region. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "kinesis-us-east-1"
+    },
+    {
+      "service_name": "AWS Billing Console",
+      "summary": "[RESOLVED] Increased Console Error Rates and latencies",
+      "date": "1572963155",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:12 AM PST</span>&nbsp;We are investigating increased AWS Billing Console error rates and latencies. We have identified the root-cause and are working on remediation.</div><div><span class=\"yellowfg\"> 6:42 AM PST</span>&nbsp;We continue to investigate increased AWS Billing Console error rates and latencies. We have identified the root-cause and are working on remediation.</div><div><span class=\"yellowfg\"> 7:41 AM PST</span>&nbsp;Remediation work for increased AWS Billing Console error rates and latencies continues. The issue affects accessing and reviewing billing information on the Billing Dashboard and Bills pages on the console.\n</div><div><span class=\"yellowfg\"> 8:48 AM PST</span>&nbsp;We continue to work on the remediation for elevated Billing Dashboard and Bills page errors. As a work-around to retrieve your invoices, please navigate to Orders and Invoices page on the AWS Billing Console and, in order to review your cost and usage information, please navigate to Cost Explorer Console.</div><div><span class=\"yellowfg\">10:17 AM PST</span>&nbsp;As of 9:50 am, we are seeing recovery of the service on Billing Dashboard and Bills pages as we continue to work through the mitigation activities. </div><div><span class=\"yellowfg\">10:44 AM PST</span>&nbsp;Between 5:06 AM and 9:50 AM PST we experienced elevated error rates and latencies affecting Billing Dashboard and Bills pages on the AWS Billing Console. The issue has been resolved and the service is operating normally.</div>",
+      "service": "billingconsole"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Change Propagation Delays",
+      "date": "1573033383",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:43 AM PST</span>&nbsp;We are investigating longer than usual propagation times to propagate certain configuration changes made either via console, CloudFront APIs, or AWS CloudFormation templates to some of our edge locations. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\"> 2:39 AM PST</span>&nbsp;We can confirm longer than usual propagation times to propagate configuration changes made either via console, CloudFront APIs, or AWS CloudFormation templates to some of our edge locations, and continue to work toward resolution. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\"> 4:03 AM PST</span>&nbsp;We continue to work on mitigating the cause of longer than usual propagation times to propagate configuration changes made either via console, CloudFront APIs, or AWS CloudFormation templates to some of our edge locations. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\"> 6:23 AM PST</span>&nbsp;Between November 5 9:52 PM and November 6 6:00 AM PST, we experienced intermittent delays in propagating CloudFront distribution changes to some edge locations. End-user requests for content from our edge locations were not affected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Auto Scaling (US-West)",
+      "summary": "[RESOLVED] Increased Auto Scaling API errors",
+      "date": "1573088299",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:58 PM PST</span>&nbsp;We are investigating increased API error rates in the US-GOV-WEST-1 Region.</div><div><span class=\"yellowfg\"> 5:31 PM PST</span>&nbsp;We continue to investigate increased API error rates in the US-GOV-WEST-1 Region.</div><div><span class=\"yellowfg\"> 6:06 PM PST</span>&nbsp;We can confirm increased API error rates in the US-GOV-WEST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 6:20 PM PST</span>&nbsp;Between 4:15 PM and 6:11 PM PST we experienced increased API error rates in the US-GOV-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "autoscaling-us-gov-west-1"
+    },
+    {
+      "service_name": "Amazon Kinesis Data Streams (Hong Kong)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1573150026",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:07 AM PST</span>&nbsp;We are investigating increased error rates for Kinesis Data Streams APIs in the AP-EAST-1 Region.</div><div><span class=\"yellowfg\">10:38 AM PST</span>&nbsp;We can confirm Kinesis Data Streams is experiencing increased error rates on all APIs in the AP-EAST-1 Region.</div><div><span class=\"yellowfg\">11:06 AM PST</span>&nbsp;Between 9:19 AM and 10:52 AM PST Kinesis Data Streams customers experienced increased error rates on all APIs in the AP-EAST-1 Region. The issue is resolved and the service is operating normally.\n</div>",
+      "service": "kinesis-ap-east-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Hong Kong)",
+      "summary": "[RESOLVED] Increased Faults and Latencies",
+      "date": "1573150195",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:09 AM PST</span>&nbsp;We are investigating increased faults and latencies for CloudWatch Metrics PutMetricData and CloudWatch Logs PutLogEvents APIs in the AP-EAST-1 Region. CloudWatch alarms may transition into \"INSUFFICIENT_DATA\" state if set on delayed metrics.</div><div><span class=\"yellowfg\">10:45 AM PST</span>&nbsp;We can confirm increased faults and latencies for CloudWatch Metrics PutMetricData and CloudWatch Logs PutLogEvents APIs in the AP-EAST-1 Region, we are actively working to resolve the issue.</div><div><span class=\"yellowfg\">10:52 AM PST</span>&nbsp;We can confirm recovery for the CloudWatch Logs PutLogEvents API and continue to work towards recovery for the Metrics PutMetricsData API in the AP-EAST-1 Region. </div><div><span class=\"yellowfg\">11:04 AM PST</span>&nbsp;Between 09:15 AM and 10:51 AM PST, some customers experienced elevated faults when calling CloudWatch Metrics PutMetricData and CloudWatch Logs PutLogEvents APIs in the AP-EAST-1 Region. Some metrics were delayed, CloudWatch alarms on delayed metrics transitioned into INSUFFICIENT_DATA state, and some metric data may be missing. The issue is resolved and the service is operating normally.</div>",
+      "service": "cloudwatch-ap-east-1"
+    },
+    {
+      "service_name": "Amazon Kinesis Firehose (Hong Kong)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1573150212",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:10 AM PST</span>&nbsp;We are investigating increased error rates for Kinesis Data Firehose APIs in the AP-EAST-1 Region.</div><div><span class=\"yellowfg\">10:41 AM PST</span>&nbsp;We can confirm Kinesis Data Firehose is experiencing increased error rates on all APIs in the AP-EAST-1 Region.</div><div><span class=\"yellowfg\">11:09 AM PST</span>&nbsp;Between 9:19 AM and 10:52 AM PST Kinesis Data Firehose customers experienced increased error rates on all APIs in the AP-EAST-1 Region. The issue is resolved and the service is operating normally.</div>",
+      "service": "firehose-ap-east-1"
+    },
+    {
+      "service_name": "Amazon DynamoDB (N. Virginia)",
+      "summary": "[RESOLVED] Increased Update Table Processing Times",
+      "date": "1573196668",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:04 PM PST</span>&nbsp;We are investigating increased processing times for update table with Amazon DynamoDB in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">11:44 PM PST</span>&nbsp;We have identified the cause of the increased processing times for update table with Amazon DynamoDB in the US-EAST-1 Region and continue working towards resolution.</div><div><span class=\"yellowfg\">Nov 8, 12:03 AM PST</span>&nbsp;Between 8:45 PM and 11:55 PM PST, we experienced increased processing times for update table with Amazon DynamoDB in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "dynamodb-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Frankfurt)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1573546089",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:08 AM PST</span>&nbsp;We are investigating increased network connectivity errors to instances in a single Availability Zone in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\">12:28 AM PST</span>&nbsp;We are experiencing elevated API error rates and network connectivity errors in a single Availability Zone. We have identified the root cause and are working to resolve the issue. </div><div><span class=\"yellowfg\"> 1:04 AM PST</span>&nbsp;Most network connectivity to instances within the impacted Availability Zone has been restored, and we are completing recovery for the remaining connectivity errors. We are continuing to experience elevated API error rates and are working to resolve this issue.</div><div><span class=\"yellowfg\"> 2:13 AM PST</span>&nbsp;Some EBS volumes are experiencing degraded performance in a single Availability Zone in the EU-CENTRAL-1 Region. We are working to resolve this issue. Network connectivity errors and elevated API error rates in the Availability Zone have been resolved. </div><div><span class=\"yellowfg\"> 6:06 AM PST</span>&nbsp;Between November 11 11:38 PM and November 12 12:48 AM PST we experienced API errors, network connectivity errors, and degraded EBS volume performance in a single Availability Zone in the EU-CENTRAL-1 Region. The network connectivity errors were resolved at 12:48 AM PST, the API errors were resolved at 1:26 AM PST. We have recovered the majority of the degraded volumes. A small number of volumes remain degraded. We continue to work to recover all affected volumes and will notify customers with impacted volumes via their Personal Health Dashboard. For immediate recovery, we recommend replacing any remaining affected volumes if possible. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Frankfurt)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1573549998",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:13 AM PST</span>&nbsp;We are continuing to investigate connectivity issues affecting some instances in a single Availability Zone in the EU-CENTRAL-1 Region. \n</div><div><span class=\"yellowfg\"> 2:23 AM PST</span>&nbsp;We are starting to see recovery for the connectivity issues affecting a small number of instances in a single Availability Zone in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\"> 5:09 AM PST</span>&nbsp;Between November 11 11:39 PM and November 12 5:00 AM PST, a small number of instances experienced connectivity issues in a single Availability Zone in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-eu-central-1"
+    },
+    {
+      "service_name": "AWS CloudFormation (Frankfurt)",
+      "summary": "[RESOLVED] Increased Stack Create, Delete and Update Times. ",
+      "date": "1573552926",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:02 AM PST</span>&nbsp;We are investigating increased latencies for creating, deleting and updating stacks in the EU-CENTRAL-1 Region. </div><div><span class=\"yellowfg\"> 3:29 AM PST</span>&nbsp;Between November 11 11:35 PM and November 12 3:25 AM PST we experienced increased latencies for creating, deleting and updating stacks in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "cloudformation-eu-central-1"
+    },
+    {
+      "service_name": "Auto Scaling (Frankfurt)",
+      "summary": "[RESOLVED] Increased Auto Scaling API errors",
+      "date": "1573556991",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:09 AM PST</span>&nbsp;We are investigating elevated API fault rate and scaling delays for EC2 Auto Scaling in the EU-CENTRAL-1 Region.</div><div><span class=\"yellowfg\"> 4:10 AM PST</span>&nbsp;Between November 11 11:44 PM PST and November 12 3:35 AM PST we experienced elevated API fault rates and scaling delays for EC2 Auto Scaling in the EU-CENTRAL-1 Region. The issue has been resolved and the service is operating normally. </div>",
+      "service": "autoscaling-eu-central-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1573583181",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:26 AM PST</span>&nbsp;We are investigating increased API error rates and latencies in the US-EAST-1 Region. Connectivity to running instances is not affected.</div><div><span class=\"yellowfg\">10:50 AM PST</span>&nbsp;We continue to work towards resolution of the issue affecting API error rates and latencies in the US-EAST-1 Region. Connectivity to running instances remains unaffected. </div><div><span class=\"yellowfg\">11:31 AM PST</span>&nbsp;We are beginning to see recovery for the increased API error rates and latencies in the US-EAST-1 Region and continue to work toward full recovery. </div><div><span class=\"yellowfg\"> 1:18 PM PST</span>&nbsp;Between 8:57 AM and 10:52 AM PST, we experienced increased API error rates and latencies in the US-EAST-1 Region. Connectivity to running instances was not affected during this event. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1573586011",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:13 AM PST</span>&nbsp;We are investigating increased API error rates and latency for some IAM APIs.</div><div><span class=\"yellowfg\">11:47 AM PST</span>&nbsp;We are beginning to see recovery for the increased API error rates and latencies and continue to work toward full recovery. </div><div><span class=\"yellowfg\"> 1:33 PM PST</span>&nbsp;Between 8:57 AM and 10:55 AM PST we experienced increased API error rates and latencies. The issue has been resolved and the service is operating normally. </div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "Amazon Connect (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1573587595",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:31 AM PST</span>&nbsp;We are investigating increased API error rates and call handling issues the US-EAST-1 Region. </div><div><span class=\"yellowfg\">12:19 PM PST</span>&nbsp;We are beginning to see recovery for the increased API error rates and call handling issues in the US-EAST-1 Region and continue to work toward full recovery. </div><div><span class=\"yellowfg\"> 1:24 PM PST</span>&nbsp;Between 8:57 AM and 12:09 PM PST we experienced increased API error rates and call handling issues in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "connect-us-east-1"
+    },
+    {
+      "service_name": "AWS Lambda (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1573591030",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:37 PM PST</span>&nbsp;We are experiencing increased error rates and latencies for actions on the AWS Lambda Management Console in the US-EAST-1 Region. AWS Lambda API calls via the SDK and CLI remain unaffected. Some invocations of scheduled Lambda function are also experiencing error rates in the US-EAST-1 Region. The root cause of these issues has been identified and we are working towards full resolution.</div><div><span class=\"yellowfg\"> 1:21 PM PST</span>&nbsp;Between 8:56 AM and 12:15 PM PST, some customers experienced increased error rates and latencies for actions on the AWS Lambda Management Console in the US-EAST-1 Region. AWS Lambda API calls via the SDK and CLI were unaffected. Between 11:22 AM and 12:40 PM PST, some invocations of scheduled Lambda functions also experienced elevated error rates in the US-EAST-1 Region. Any unprocessed invocations for affected functions have been reprocessed based on the retry policy on the function. The issue has been resolved and the service is operating normally.</div>",
+      "service": "lambda-us-east-1"
+    },
+    {
+      "service_name": "Amazon Kinesis Analytics (N. Virginia)",
+      "summary": "[RESOLVED] Applications not processing data",
+      "date": "1573673937",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:38 AM PST</span>&nbsp;We are currently investigating issues with Amazon Kinesis Data Analytics applications that are not processing data in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">12:12 PM PST</span>&nbsp;Between 10:08 AM PST and 12:10 PM PST a subset of Amazon Kinesis Data Analytics applications were not processing data in US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "kinesisanalytics-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates for EC2 Spot",
+      "date": "1573890252",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:44 PM PST</span>&nbsp;We are investigating increased API error rates for EC2 Spot-related APIs in the US-EAST-1 Region. Affected customers will not be able to launch new EC2 Spot instances, but existing instances are unaffected. Launching new EC2 On-Demand Instances is unaffected.</div><div><span class=\"yellowfg\">Nov 16, 12:03 AM PST</span>&nbsp;We are investigating increased API error rates for EC2 Spot-related APIs in the US-EAST-1 Region. Affected customers will not be able to launch new EC2 Spot instances, but existing instances are unaffected. Launching new EC2 On-Demand Instances is unaffected. We have identified the root cause and are working towards resolution.</div><div><span class=\"yellowfg\">Nov 16,  1:41 AM PST</span>&nbsp;Between November 15 10:30 PM and November 16 1:19 AM PST, we experienced increased API latencies and error rates for EC2 Spot APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "AWS Elastic Beanstalk (N. Virginia)",
+      "summary": "Increased API Error Rates ",
+      "date": "1574595711",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:41 AM PST</span>&nbsp;We are currently investigating increased error rates for the Elastic Beanstalk Health APIs in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 4:07 AM PST</span>&nbsp;Between 1:20 AM and 3:50 AM PST, we experienced increased error rates for the Elastic Beanstalk Health APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticbeanstalk-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Sydney)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1574731819",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:30 PM PST</span>&nbsp;We are investigating increased Console and API error rates in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 5:55 PM PST</span>&nbsp;We have identified the root cause of the issue causing increased error rates and latencies for the EC2 and EBS APIs in the AP-SOUTHEAST-2 Region. Existing instances are not affected by this issue. We are working towards resolution of the issue.</div><div><span class=\"yellowfg\"> 6:28 PM PST</span>&nbsp;We are seeing recovery for the increased error rates and latencies for the EC2 and EBS APIs in the AP-SOUTHEAST-2 Region. We continue to monitor error rates and latencies as we work towards full recovery.</div><div><span class=\"yellowfg\"> 7:33 PM PST</span>&nbsp;Between 4:52 PM and 6:22 PM PST we experienced increased error rates and latencies for the EC2 and EBS APIs in the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-ap-southeast-2"
+    },
+    {
+      "service_name": "Auto Scaling (Sydney)",
+      "summary": "[RESOLVED] Increased Launch Times ",
+      "date": "1574732926",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:48 PM PST</span>&nbsp;We are investigating increased launch times for EC2 instances managed by Auto Scaling in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 6:13 PM PST</span>&nbsp;We continue to work towards resolving the issue causing increased launch times for Auto Scaling in the AP-SOUTHEAST-2 Region. All affected launches will complete successfully once the increased error rates and latencies for the EC2 APIs have been resolved.</div><div><span class=\"yellowfg\"> 6:29 PM PST</span>&nbsp;With the improvement in error rates and latencies for the EC2 APIs, Auto Scaling launches are once again succeeding. We're now working through the backlog of pending launches.</div><div><span class=\"yellowfg\"> 7:33 PM PST</span>&nbsp;Between 4:52 PM and 6:22 PM PST we experienced increased launch latencies for Auto Scaling in the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "autoscaling-ap-southeast-2"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased SAML Sign-In Error Rates",
+      "date": "1576790068",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:14 PM PST</span>&nbsp;We are investigating increased error rates for SAML-based sign-in requests. Sign-in requests for other Roles and users are not affected.</div><div><span class=\"yellowfg\"> 2:14 PM PST</span>&nbsp;We can confirm increased error rates for SAML-based sign-in requests. Sign-in requests for other Roles and users are not affected. We continue to investigate increased error rates for SAML-based sign-in requests.</div><div><span class=\"yellowfg\"> 2:37 PM PST</span>&nbsp;We are beginning to see recovery for the increased error rates impacting SAML-based sign-in requests. We continue to work toward full recovery. </div><div><span class=\"yellowfg\"> 3:21 PM PST</span>&nbsp;Between 11:23 AM and 2:42 PM PST we experienced increased error rates impacting SAML-based sign-in requests. During this time customers may have been unable to authenticate to the AWS Console when using SAML for sign-in requests. The issue has been resolved and the service is operating normally. </div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Elevated CloudFront API errors",
+      "date": "1577471528",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:32 AM PST</span>&nbsp;We are investigating increased CloudFront API errors and longer than usual propagation times while making changes to CloudFront configurations. End-user requests for content from edge locations are not affected.</div><div><span class=\"yellowfg\">11:16 AM PST</span>&nbsp;We have resolved the issues related to CloudFront APIs. We have identified the root cause of the longer than usual change propagation delays for invalidations and CloudFront configurations and are actively working towards resolution. End-user requests for content from edge locations are not affected and continue to be served normally.</div><div><span class=\"yellowfg\">12:04 PM PST</span>&nbsp;Between 9:30 AM and 11:01 AM PST, customers may have seen elevated CloudFront API errors. These have now been resolved. Due to these API errors there was a backlog of changes that resulted in longer than usual change propagation delays for CloudFront configurations and invalidations. This backlog of changes is actively being processed. End-user requests for content from edge locations are not affected and continue to be served normally.</div><div><span class=\"yellowfg\"> 2:01 PM PST</span>&nbsp;Between 9:30 AM and 11:01 AM PST, customers may have seen elevated CloudFront API errors. Due to these API errors there was a backlog of changes that resulted in longer than usual change propagation delays for CloudFront configurations and invalidations. The backlog of Invalidation changes were fully processed by 11:35 AM. The backlog of CloudFront configuration changes was fully processed by 2:00 PM PST. All issues have been fully resolved and the system is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "AWS Lambda (Ireland)",
+      "summary": "[RESOLVED] Increased delays in event processing from Streams ",
+      "date": "1578446772",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:26 PM PST</span>&nbsp;Between 4:05 PM PST and 5:20 PM PST, customers using Lambda functions to process events from Kinesis Data Streams and DynamoDB Streams experienced significant delays in event processing for a subset of functions in the EU-WEST-1 Region. The issue has been resolved and the service is operating normally. The backlogged events will be processed by the function over the next few hours as per the retry policy on the event source mapping on the affected functions.</div>",
+      "service": "lambda-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Chime",
+      "summary": "[RESOLVED] Availability",
+      "date": "1579119985",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:26 PM PST</span>&nbsp;We are currently investigating increased application faults and decreased availability for Amazon Chime.</div><div><span class=\"yellowfg\">12:45 PM PST</span>&nbsp;We have identified the root cause of the increased application faults and decreased availability for Amazon Chime. Customers who are already signed into the Chime Client are not advised to logout, or select the re-connection option.</div><div><span class=\"yellowfg\"> 1:36 PM PST</span>&nbsp;We have identified the root cause of the increased application faults and decreased availability for Amazon Chime, and can confirm recovery for some users. Customers who are already signed into the Chime Client are not advised to logout, or select the re-connection option, as we continue to work towards resolution.</div><div><span class=\"yellowfg\"> 2:30 PM PST</span>&nbsp;We have identified the root cause of the increased application faults and decreased availability for Amazon Chime, and can confirm recovery for audio meeting and chat features. We continue to work towards resolving decreased video conferencing availability.</div><div><span class=\"yellowfg\"> 3:11 PM PST</span>&nbsp;Between 11:49 AM and 3:08 PM PST we experienced increased application faults and decreased availability for Amazon Chime. The issue has been resolved and the service is operating normally.</div>",
+      "service": "chime"
+    },
+    {
+      "service_name": "AWS Certificate Manager (N. Virginia)",
+      "summary": "[RESOLVED] Certificate Issuance Delays",
+      "date": "1579134535",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:28 PM PST</span>&nbsp;We have identified the cause of the increased delays in validation and issuance for DNS validated domains in the US-EAST-1 Region and are working to mitigate the issue. Certificates can be requested but will be delayed in issuance.</div><div><span class=\"yellowfg\"> 4:58 PM PST</span>&nbsp;We continue to work towards mitigating the increased delays in validation and issuance for DNS validated domains in the US-EAST-1 Region. Certificates that are DNS validated can be requested but will be delayed in issuance.</div><div><span class=\"yellowfg\"> 6:20 PM PST</span>&nbsp;Between 3:05 PM and 6:11 PM PST we experienced increased delays in validation and issuance for DNS validated domains in the US-EAST-1 Region. The issue has been resolved and the service is operating normally. Certificates waiting for DNS validation which have proper CNAME entries in DNS will validate within the next 3 hours.</div>",
+      "service": "certificatemanager-us-east-1"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "Increased Error Rates and Latencies",
+      "date": "1579369796",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 9:49 AM PST</span>&nbsp;Starting at 7:30 AM PST, we have been experiencing increased error rates due to higher latency for IAM requests. We are actively investigating the issue. </div><div><span class=\"yellowfg\">10:05 AM PST</span>&nbsp;Between 7:30 AM and 9:45 AM PST, we experienced increased error rates due to higher latency for IAM requests. The system has recovered and is operating normally.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Mumbai)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1579421028",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:03 AM PST</span>&nbsp;We are investigating increased API error rates in the AP-SOUTH-1 Region.</div><div><span class=\"yellowfg\">12:35 AM PST</span>&nbsp;Between January 18 11:18 PM and January 19 12:14 AM PST we experienced increased API error rate in the AP-SOUTH-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-ap-south-1"
+    },
+    {
+      "service_name": "AWS Internet Connectivity (Paris)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1579717555",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:25 AM PST</span>&nbsp;We are investigating an issue which is affecting internet connectivity to a single availability zone in EU-WEST-3 Region.</div><div><span class=\"yellowfg\">11:05 AM PST</span>&nbsp;We have identified the root cause of the issue that is affecting connectivity to a single availability zone in EU-WEST-3 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\">11:45 AM PST</span>&nbsp;Between 10:00 AM and 11:28 AM PST we experienced an issue affecting network connectivity to AWS services in a single Availability Zone in EU-WEST-3 Region. The issue has been resolved and connectivity has been restored.</div>",
+      "service": "internetconnectivity-eu-west-3"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Paris)",
+      "summary": "[RESOLVED] Network Connectivity",
+      "date": "1579723478",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:04 PM PST</span>&nbsp;Between 10:00 AM and 11:28 AM PST we experienced network connectivity issues affecting EC2 instances in a single Availability Zone in the EU-WEST-3 Region. Instances in the affected Availability Zone were able to connect to the Internet but were unable to resolve DNS records during this time. New instance launches into the affected Availability Zone were also affected by the event. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-west-3"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Sydney)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1579740075",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:41 PM PST</span>&nbsp;We are investigating increased API error rates and latencies in the AP-SOUTHEAST-2 Region. Connectivity to existing instances is not impacted.</div><div><span class=\"yellowfg\"> 5:18 PM PST</span>&nbsp;We have identified the root cause of the issue causing increased API error rates and latencies in the AP-SOUTHEAST-2 Region and continue working towards resolution. This issue mainly affects EC2 RunInstances and VPC related API requests. Customer using the EC2 Management Console will also experience error rates for instance and network related functions. Connectivity to existing instances remains unaffected.</div><div><span class=\"yellowfg\"> 6:25 PM PST</span>&nbsp;We continue to experience increased API error rates for the EC2 APIs in the AP-SOUTHEAST-2 Region. We have confirmed the root cause, and are working on multiple paths toward recovering the subsytem that is impaired, which is responsible for networking related API calls. This issue mainly affects EC2 RunInstance, and VPC related API requests. Customers using the EC2 Management Console may experience errors Describing Resources, as well as making mutating API requests. Connectivity to existing instances in the AP-SOUTHEAST-2 remains unaffected.</div><div><span class=\"yellowfg\"> 8:49 PM PST</span>&nbsp;We wanted to provide you with more details on the issue causing increased API error rates and latencies in the AP-SOUTHEAST-2 Region. A data store used by a subsystem responsible for the configuration of Virtual Private Cloud (VPC) networks is currently offline and the engineering team are working to restore it. While the investigation into the issue was started immediately, it took us longer to understand the full extent of the issue and determine a path to recovery. We determined that the data store needed to be restored to a point before the issue began. In order to do this restore, we needed to disable writes. Error rates and latencies for the networking-related APIs will continue until the restore has been completed and writes re-enabled. We are working through the recovery process now. With issues like this, it is always difficult to provide an accurate ETA, but we expect to complete the restore process within the next 2 hours and begin to allow API requests to proceed once again. We will continue to keep you updated if that ETA changes. Connectivity to existing instances is not impacted. Also, launch requests that refer to regional objects like subnets that already exist will succeed at this stage, as they do not depend on the affected subsystem. If you know the subnet ID, you can use that to launch instances within the region. We apologize for the impact and continue to work towards full resolution. </div><div><span class=\"yellowfg\">10:10 PM PST</span>&nbsp;We continue to make steady progress towards the restoration of the affected data store and are currently within the 2 hours ETA published above.</div><div><span class=\"yellowfg\">10:55 PM PST</span>&nbsp;We have completed the restoration of the affected data store but are still working towards re-enabling writes. We have seen an improvement in successful launches over the last 20 minutes and expect that to continue as we work towards full recovery. </div><div><span class=\"yellowfg\">11:45 PM PST</span>&nbsp;We can confirm that all error rates and latencies have returned to normal levels. The issue has been resolved and the service is operating normally.</div><div><span class=\"yellowfg\">Jan 23, 12:30 AM PST</span>&nbsp;Now that we are fully recovered, we wanted to provide a brief summary of the issue. Starting at 4:07 PM PST, customers began to experience increased error rates and latencies for the network-related APIs in the AP-SOUTHEAST-2 Region. Launches of new EC2 instances also experienced increased failure rates as a result of this issue. Connectivity to existing instances was not affected by this event. We immediately began investigating the root cause and identified that the data store used by the subsystem responsible for the Virtual Private Cloud (VPC) regional state was impaired. While the investigation into the issue was started immediately, it took us longer to understand the full extent of the issue and determine a path to recovery. We determined that the data store needed to be restored to a point before the issue began. We began the data store restoration process, which took a few hours and by 10:50 PM PST, we had fully restored the primary node in the affected data store. At this stage, we began to see recovery in instance launches within the AP-SOUTHEAST-2 Region, restoring many customer applications and services to a healthy state. We continued to bring the data store back to a fully operational state and by 11:20 PM PST, all API error rates and latencies had fully recovered. Other AWS services - including AppStream, Elastic Load Balancing, ElastiCache, Relational Database Service, Amazon WorkSpaces and Lambda â€“ were also affected by this event. We apologize for any inconvenience this event may have caused as we know how critical our services are to our customers. We are never satisfied with operational performance of our services that is anything less than perfect, and will do everything we can to learn from this event and drive improvement across our services.</div>",
+      "service": "ec2-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Relational Database Service (Sydney)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1579742960",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:29 PM PST</span>&nbsp;We are investigating increased API error rates and latencies in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 6:20 PM PST</span>&nbsp;We can confirm increased API error rates and latencies in the AP-SOUTHEAST-2 Region and continue to work towards resolution. Connectivity to existing instances remains unaffected.</div><div><span class=\"yellowfg\"> 7:35 PM PST</span>&nbsp;We are continuing to work towards resolution of increased API error rates and latencies in the AP-SOUTHEAST-2 Region. Connectivity to existing instances remains unaffected.</div><div><span class=\"yellowfg\"> 9:00 PM PST</span>&nbsp;We continue to experience increased API error rates and latencies due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. We continue to work towards full resolution.</div><div><span class=\"yellowfg\">11:38 PM PST</span>&nbsp;Between 4:41 PM and 11:35 PM PDT we experienced increased API error rates and latencies due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "rds-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (Sydney)",
+      "summary": "[RESOLVED] Increased Provisioning Latencies",
+      "date": "1579743205",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:33 PM PST</span>&nbsp;We are investigating increased provisioning times and ELB API error rates for load balancers in the AP-SOUTHEAST-2 Region. Connectivity to existing load balancers is not affected.</div><div><span class=\"yellowfg\"> 6:13 PM PST</span>&nbsp;We can confirm increased provisioning/scaling latencies and ELB API error rates for load balancers in the AP-SOUTHEAST-2 Region and continue to work towards resolution. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\"> 7:23 PM PST</span>&nbsp;We are continuing to work towards resolution of increased provisioning/scaling latencies and ELB API error rates for load balancers in the AP-SOUTHEAST-2 Region. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\"> 8:59 PM PST</span>&nbsp;We continue to experience increased provisioning/scaling latencies and ELB API error rates for load balancers due to the issue affecting EC2 in the AP-SOUTHEAST-2 Region. We continue to work towards full resolution. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\">Jan 23, 12:22 AM PST</span>&nbsp;Between 4:10 PM and 11:40 PM PST, we experienced increased provisioning/scaling latencies and ELB API error rates for load balancers due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elb-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon AppStream 2.0 (Sydney)",
+      "summary": "[RESOLVED] Increased Instance Provisioning Error Rates",
+      "date": "1579745293",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:08 PM PST</span>&nbsp;We are currently experiencing an issue provisioning new image builder and fleet streaming instances in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 7:20 PM PST</span>&nbsp;We are continuing to investigate an increase in instance provisioning error rates in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 8:32 PM PST</span>&nbsp;We have identified the cause of the increased provisioning error rates in the AP-SOUTHEAST-2 Region and continue working towards resolution.</div><div><span class=\"yellowfg\"> 8:59 PM PST</span>&nbsp;We continue to experience increased instance provisioning error rates due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. We continue to work towards full resolution. Existing streaming sessions and instances will continue to operate.</div><div><span class=\"yellowfg\">Jan 23, 12:41 AM PST</span>&nbsp;We continue to experience increased instance provisioning error rates within the AP-SOUTHEAST-2 Region. We continue to work towards full resolution. Existing streaming sessions and instances will continue to operate.</div><div><span class=\"yellowfg\">Jan 23,  1:51 AM PST</span>&nbsp;We are continuing to work towards resolution of increased instance provisioning error rates within the AP-SOUTHEAST-2 Region. Existing streaming sessions and instances will continue to operate.</div><div><span class=\"yellowfg\">Jan 23,  2:38 AM PST</span>&nbsp;We recently experienced increased instance provisioning errors within the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "appstream2-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon ElastiCache (Sydney)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1579748460",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:01 PM PST</span>&nbsp;We are experiencing increased latencies while provisioning new ElastiCache nodes and and elevated API error rates in the AP-SOUTHEAST-2 AWS Region. Existing ElastiCache clusters are not impacted and are continuing to serve traffic. We are working to resolve the issue.</div><div><span class=\"yellowfg\"> 9:32 PM PST</span>&nbsp;We continue to experience increased latencies for ElastiCache cluster creation, modification and deletion operations, and elevated API error rates due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. We continue to work towards full resolution. Existing clusters are operating normally.</div><div><span class=\"yellowfg\">11:55 PM PST</span>&nbsp;Between 4:09 PM and 11:44 PM PST, we experienced increased latencies for ElastiCache cluster creation, modification and deletion operations, and elevated API error rates due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticache-ap-southeast-2"
+    },
+    {
+      "service_name": "AWS Lambda (Sydney)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1579749477",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:17 PM PST</span>&nbsp;We can confirm increased API error rates in the AP-SOUTHEAST-2 Region for functions that are configured with VPC settings. Functions that are not configured with VPC settings are unaffected.</div><div><span class=\"yellowfg\"> 9:02 PM PST</span>&nbsp;We continue to experience increased API error rates in the AP-SOUTHEAST-2 Region for functions that are configured with VPC settings due to the issue affecting EC2 in the AP-SOUTHEAST-2 Region. We continue to work towards full resolution.</div><div><span class=\"yellowfg\">11:31 PM PST</span>&nbsp;Between 4:50 PM and 11:00 PM PST, we experienced increased API error rates for functions due to an issue affecting EC2 in the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "lambda-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon WorkSpaces (Sydney)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1579750287",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:31 PM PST</span>&nbsp;We are investigating increased Amazon WorkSpaces API error rates and provisioning times for Amazon WorkSpaces in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 8:39 PM PST</span>&nbsp;We have identified the cause of increased Amazon WorkSpaces API error rates and provisioning times for Amazon WorkSpaces in the AP-SOUTHEAST-2 Region and continue working towards resolution.</div><div><span class=\"yellowfg\"> 9:02 PM PST</span>&nbsp;We continue to experience increased API error rates and provisioning times for Amazon WorkSpaces due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. Existing Amazon WorkSpaces sessions will continue to operate.</div><div><span class=\"yellowfg\">11:32 PM PST</span>&nbsp;Between 4:04 PM and 10:55 PM PST, we experienced increased Amazon WorkSpaces API error rates and provisioning times due to the issue affecting EC2 within the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is now operating normally.</div>",
+      "service": "workspaces-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Route 53 DNS Change Issues ",
+      "date": "1579899055",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:50 PM PST</span>&nbsp;We are investigating increased propagation times of DNS edits to the Route 53 DNS servers. Queries to existing DNS records are not affected by this issue.</div><div><span class=\"yellowfg\"> 1:21 PM PST</span>&nbsp;We are still investigating increased propagation times of DNS edits to the Route 53 DNS servers. This will affect provisioning of new resources that rely on Route 53 for DNS, such as EFS and PrivateLink. Queries to existing DNS records are not affected by this issue</div><div><span class=\"yellowfg\"> 1:38 PM PST</span>&nbsp;We are still investigating increased propagation times of DNS edits to the Route 53 DNS servers. To help accelerate recovery, the Route 53 API is temporarily not accepting MakeChange or CreateHostedZone requests. This will also affect provisioning of new resources that rely on Route 53 for DNS, such as: EFS, PrivateLink, Amazon MQ, Amazon Managed Streaming for Apache Kafka, API Gateway.  Queries to existing DNS records are not affected by this issue. </div><div><span class=\"yellowfg\"> 2:58 PM PST</span>&nbsp;We are still investigating increased propagation times of DNS edits to the Route 53 DNS servers. To help accelerate recovery, the Route 53 API is temporarily not accepting MakeChange or CreateHostedZone requests. Queries to existing DNS records are not affected by this issue. This will also affect provisioning of new resources that rely on Route 53 for DNS, such as: EFS, PrivateLink, Amazon MQ, Amazon Managed Streaming for Apache Kafka, API Gateway, DocumentDB, FSx for Lustre, Certificate Manager, Transfer for SFTP, EKS, CloudFormation and Chime Voice Connector.</div><div><span class=\"yellowfg\"> 3:08 PM PST</span>&nbsp;We have identified root cause resulting in increased propagation times of DNS edits to the Route 53 DNS servers. The Route 53 API is temporarily not accepting MakeChange or CreateHostedZone requests in order to help accelerate recovery. Queries to existing DNS records are not affected by this issue. This will also affect provisioning of new resources that rely on Route 53 for DNS, such as: EFS, PrivateLink, Amazon MQ, Amazon Managed Streaming for Apache Kafka, API Gateway, DocumentDB, FSx for Lustre, Certificate Manager, Transfer for SFTP, EKS, CloudFormation, Chime Voice Connector and Global Accelerator.</div><div><span class=\"yellowfg\"> 3:45 PM PST</span>&nbsp;We have identified root cause resulting in increased propagation times of DNS edits to the Route 53 DNS servers, and are working towards recovery. The Route 53 API is now accepting changes again, though these changes are still experiencing delays propagating as there is a significant backlog of changes to process. Queries to existing DNS records are not affected by this issue. This will also affect provisioning of new resources that rely on Route 53 for DNS, such as: EFS, PrivateLink, Amazon MQ, Amazon Managed Streaming for Apache Kafka, API Gateway, DocumentDB, FSx for Lustre, Certificate Manager, Transfer for SFTP, EKS, CloudFormation, Chime Voice Connector, Global Accelerator, RDS, SageMaker Ground Truth, Amazon Managed Blockchain and Directory Service.</div><div><span class=\"yellowfg\"> 5:21 PM PST</span>&nbsp;Between 12:07 PM and 5:15 PM PST, customers experienced delays propagating changes submitted to the Route 53 API, as well as increased API error rates from 1:55 PM until 3:20 PM. This also affected provisioning of new resources that rely on Route 53 DNS, such as EFS, PrivateLink, Amazon MQ, Amazon Managed Streaming for Apache Kafka, API Gateway, DocumentDB, FSx for Lustre, Certificate Manager, Transfer for SFTP, EKS, CloudFormation, Chime Voice Connector, Global Accelerator, RDS, SageMaker Ground Truth, Amazon Managed Blockchain, Directory Service and Elastic Inference. The Route 53 API is now operating normally, and all changes that were accepted by the Route 53 API have been propagated. Queries for all existing records were answered normally during this time.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Change Propagation Delays",
+      "date": "1580371190",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:59 PM PST</span>&nbsp;We are investigating longer than usual propagation times for changes to CloudFront configurations. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\">Jan 30, 12:15 AM PST</span>&nbsp;We have confirmed that we are seeing increased propagation times for changes to a few CloudFront edge locations. Majority of CloudFront edge locations are consuming configuration changes normally. End-user requests for content from our edge locations are not affected by this issue and are being served normally. </div><div><span class=\"yellowfg\">Jan 30,  1:23 AM PST</span>&nbsp;Between January 29 9:12 PM and January 30 12:48 AM PST we experienced delays in propagation times for changes to CloudFront configurations. During this time end-user requests for content from our edge locations were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rate",
+      "date": "1580754533",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:28 AM PST</span>&nbsp;We are investigating increased error rates and latencies for ELB APIs in the US-EAST-1 Region. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\">10:45 AM PST</span>&nbsp;We have identified the root cause of the increased error rates and continue to work toward full resolution.</div><div><span class=\"yellowfg\">11:24 AM PST</span>&nbsp;Between 9:55 and 11:17 AM PST, we experienced increased error rates and latencies in the US-EAST-1 region. Traffic on existing load balancers was unaffected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elb-us-east-1"
+    },
+    {
+      "service_name": "AWS Certificate Manager (N. Virginia)",
+      "summary": "[RESOLVED]  Certificate Issuance Delays",
+      "date": "1580774436",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:00 PM PST</span>&nbsp;We are investigating delays in certificate issuance globally. This does not impact existing certificates. Other dependent services utilizing Certificate Manager may be affected.</div><div><span class=\"yellowfg\"> 4:34 PM PST</span>&nbsp;Between 12:30 PM and 3:50 PM PST, we experienced delays in issuance of new certificates globally. Existing certificates were unaffected. The issue has been resolved and the service is operating normally. </div>",
+      "service": "certificatemanager-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Increased Console Errors",
+      "date": "1581553041",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:17 PM PST</span>&nbsp;Between 1:10 PM and 3:47 PM PST we experienced periods of increased error rates when accessing the CloudFront Management Console. Customers may have received a 404 Response. Existing distributions and the CloudFront APIs were not impacted by this issue. The issue has been resolved and the CloudFront Management Console is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Auto Scaling (US-West)",
+      "summary": "[RESOLVED] Increased error rates and latencies",
+      "date": "1581624138",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:02 PM PST</span>&nbsp;We are investigating increased error rates and latencies for Autoscaling API calls in the US-GOV-WEST-1 Region.</div><div><span class=\"yellowfg\">12:19 PM PST</span>&nbsp;Between 11:34 AM and 12:05 PM PST we experienced increased error rates and latencies for Autoscaling API calls in the US-GOV-WEST-1 Region. The issue is resolved and the service is operating normally.</div>",
+      "service": "autoscaling-us-gov-west-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (N. Virginia)",
+      "summary": "[RESOLVED] Elevated query error rates and delays for CloudWatch Logs Insights in US-EAST-1 Region",
+      "date": "1583302711",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:18 PM PST</span>&nbsp;We can confirm increased error rates for CloudWatch Logs Insights queries in the US-EAST-1 Region. Customers running queries using the StartQuery API may not be able to successfully schedule the query execution. Log events continue to be available through the CloudWatch Logs GetLogEvents and FilterLogEvents APIs. We are actively working to resolve the issue.</div><div><span class=\"yellowfg\">11:02 PM PST</span>&nbsp;We have identified the cause of the increased error rates for CloudWatch Logs Insights queries in the US-EAST-1 Region. Customers running queries using the StartQuery API may not be able to successfully schedule the query execution. Log events continue to be available through the CloudWatch Logs GetLogEvents and FilterLogEvents APIs. We continue to work towards resolution.</div><div><span class=\"yellowfg\">Mar 4, 12:13 AM PST</span>&nbsp;We have resolved the increased error rates for CloudWatch Logs Insights queries in the US-EAST-1 Region. The Logs Insights system is currently processing data starting from 8:25 PM PST until now to make it available to query. Until that process completes, customers running Logs Insights queries using the CloudWatch console or the SDK may not be able to see that data from that time period. We continue to work towards full resolution.</div><div><span class=\"yellowfg\">Mar 4,  2:40 AM PST</span>&nbsp;We have resolved the increased error rates for CloudWatch Logs Insights queries in the US-EAST-1 Region. The Logs Insights system is currently processing data starting from March 3 8:25 PM PST until now to make it available to query. Until that process completes, customers running Logs Insights queries using the CloudWatch console or the SDK may not be able to see that data from that time period. We have identified the issue and continue to work towards full resolution.</div><div><span class=\"yellowfg\">Mar 4,  6:40 AM PST</span>&nbsp;Between March 3, 8:25 PM and March 4, 6:17 AM PST, some customers experienced increased delays for log events in query results in CloudWatch Logs Insights in the US-EAST-1 Region. We are in the process of backfilling the data. We have resolved the issue and the service is operating normally.</div>",
+      "service": "cloudwatch-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Load Balancing (N. Virginia)",
+      "summary": "[RESOLVED] Increased error rates and latencies",
+      "date": "1583444770",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:46 PM PST</span>&nbsp;We are investigating increased error rates and latencies for ELB APIs in the US-EAST-1 Region. This issue does not affect traffic on running load balancers.</div><div><span class=\"yellowfg\"> 2:05 PM PST</span>&nbsp;We can confirm increased error rates and latencies for ELB APIs in the US-EAST-1 Region and continue to work towards resolution. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\"> 2:25 PM PST</span>&nbsp;We have identified the root cause of increased error rates and latencies for ELB APIs in the US-EAST-1 Region and continue to work towards resolution. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\"> 2:48 PM PST</span>&nbsp;We have addressed one of the causes of increased error rates and latencies for ELB APIs in the US-EAST-1 Region, and continue to work towards resolution. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\"> 3:33 PM PST</span>&nbsp;We have recovered from increased error rates and latencies for ELB APIs in the US-EAST-1 Region, and continue to work towards resolution of increased back-end instance registration times. Traffic remains unaffected on running load balancers.</div><div><span class=\"yellowfg\"> 3:52 PM PST</span>&nbsp;Between 1:25 PM and 3:40 PM PST, we experienced increased API error rates and latencies as well as increased back-end instance registration times in the US-EAST-1 Region. The issue is resolved and the service is operating normally.</div>",
+      "service": "elb-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Sydney)",
+      "summary": "[RESOLVED] EC2 Launch Failures",
+      "date": "1583881487",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:04 PM PDT</span>&nbsp;We are investigating increased error rates for new launches in a single Availability Zone in the AP-SOUTHEAST-2 Region.</div><div><span class=\"yellowfg\"> 4:41 PM PDT</span>&nbsp;We are still investigating increased error rates for new launches in a single Availability Zone in the AP-SOUTHEAST-2 Region and continue working towards resolution.</div><div><span class=\"yellowfg\"> 5:04 PM PDT</span>&nbsp;Between 2:15 PM and 4:40 PM PDT we experienced increased error rates for new launches in a single Availability Zone in the AP-SOUTHEAST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-ap-southeast-2"
+    },
+    {
+      "service_name": "Amazon Route 53",
+      "summary": "[RESOLVED] Increased Route 53 Console Errors",
+      "date": "1583949127",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">10:52 AM PDT</span>&nbsp;We have confirmed an issue with the Route 53 console which is causing an increased error rate. All calls to the Route 53 API and DNS servers are being answered normally.</div><div><span class=\"yellowfg\">11:11 AM PDT</span>&nbsp;Between 10:29 AM and 10:37 AM PDT customers experienced an elevated error rate when accessing the Route 53 Console. The issue has been resolved and all console requests are being answered normally. There was no impact to the Route 53 API, DNS, or Health Checking services, which were all operating normally during this time.</div>",
+      "service": "route53"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (US-West)",
+      "summary": "[RESOLVED] Increased Launch Error Rates",
+      "date": "1584350375",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:19 AM PDT</span>&nbsp;We are investigating increased error rates for new launches in a single Availability Zone in the US-GOV-WEST-1 Region.</div><div><span class=\"yellowfg\"> 2:37 AM PDT</span>&nbsp;We are currently experiencing increased error rates for new instance launches in the US-GOV-WEST-1 Region. Existing instances are not affected.</div><div><span class=\"yellowfg\"> 3:18 AM PDT</span>&nbsp;Between 1:47 AM and 3:02 AM PDT we experienced increased error rates for new instance launches in the US-GOV-WEST-1 Region. Existing instances were unaffected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-gov-west-1"
+    },
+    {
+      "service_name": "AWS CodeBuild (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates for Builds",
+      "date": "1585097779",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:56 PM PDT</span>&nbsp;We can confirm increased Build error rates in the US-WEST-2 Region. We have identified the root cause and are working toward resolution. </div><div><span class=\"yellowfg\"> 6:26 PM PDT</span>&nbsp;Between 4:05 PM and 5:51 PM PDT we experienced increased build errors due to a missing dependency in the build workflow. The issue has been resolved and the service is operating normally. </div>",
+      "service": "codebuild-us-west-2"
+    },
+    {
+      "service_name": "AWS Marketplace",
+      "summary": "[RESOLVED] Increased Subscription Error Rates ",
+      "date": "1585144373",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:52 AM PDT</span>&nbsp;We are investigating increased AWS Marketplace subscription error rates. </div><div><span class=\"yellowfg\"> 7:21 AM PDT</span>&nbsp;We have identified the cause of the increased AWS Marketplace subscription error rates and continue working towards resolution.</div><div><span class=\"yellowfg\"> 8:41 AM PDT</span>&nbsp;Between 5:05 AM and 8:30 AM PDT we experienced increased AWS Marketplace subscription error rates. The issue has been resolved and the service is operating normally.</div>",
+      "service": "marketplace"
+    },
+    {
+      "service_name": "Amazon Simple Email Service (N. Virginia)",
+      "summary": "[RESOLVED] Increased Email Receiving Latencies",
+      "date": "1585342008",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:46 PM PDT</span>&nbsp;We are currently investigating elevated latencies in our email-sending APIs in the US-EAST-1 Region. This includes the SendEmail/SendRawEmail APIs as well as calls made to the SMTP endpoint.</div><div><span class=\"yellowfg\"> 2:20 PM PDT</span>&nbsp;Between 12:25 PM and 1:52 PM PDT we experienced elevated delivery delays in the US-EAST-1 Region for mail sent to a specific external email provider. This issue impacted the SendEmail/SendRawEmail APIs as well as calls made to the SMTP endpoint. All delayed emails have now been delivered. The issue has been resolved and the service is operating normally. </div>",
+      "service": "ses-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] CloudFront High error rates",
+      "date": "1585610898",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:28 PM PDT</span>&nbsp;We are investigating elevated error rates and elevated latency in multiple edge locations. </div><div><span class=\"yellowfg\"> 5:08 PM PDT</span>&nbsp;We can confirm elevated error rates and high latency accessing content from multiple Edge Locations, which is also contributing to longer than usual propagation times for changes to CloudFront configurations. We have identified the root cause and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 5:54 PM PDT</span>&nbsp;We are beginning to see recovery for the elevated error rates and high latency accessing content from multiple Edge Locations. Error rates have recovered for all locations except for Europe. Additionally, we continue to work toward recovery for the increased delays in propagating configuration changes to Cloudfront Distributions. </div><div><span class=\"yellowfg\"> 6:21 PM PDT</span>&nbsp;Starting 3:18 PM PDT, we experienced elevated error rates and high latency accessing content from multiple Edge Locations. The elevated error rates and elevated latency accessing content were fully recovered at 5:48 PM PDT. During this time, customers may also have experienced longer than usual change propagation delays for CloudFront configurations and invalidations. The backlog of CloudFront configuration changes and invalidations were fully processed by 6:14 PM PDT. All issues have been fully resolved and the system is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased Launch Errors &amp; API Errors",
+      "date": "1586473044",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:57 PM PDT</span>&nbsp;We are investigating increased error rates for new launches in a single Availability Zone in the US-EAST-1 Region. </div><div><span class=\"yellowfg\"> 4:21 PM PDT</span>&nbsp;We can confirm increased error rates for new launches and API errors for RunInstances, AttachVolume and AttachNetworkInterface in a single Availability Zone in the US-EAST-1 Region. We continue to work towards resolution.</div><div><span class=\"yellowfg\"> 4:54 PM PDT</span>&nbsp;We have identified the root cause resulting in increased error rates for new instance launches and API errors for RunInstances, AttachVolume and AttachNetworkInterface in a single Availability Zone in the US-EAST-1 Region. We are seeing signs of recovery and continue to work toward full resolution.</div><div><span class=\"yellowfg\"> 5:48 PM PDT</span>&nbsp;Between 3:26 PM and 5:44 PM PDT we experienced increased error rates for new instance launches and periods of API errors for RunInstances, AttachVolume and AttachNetworkInterface in a single Availability Zone in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Queue Service (N. Virginia)",
+      "summary": "[RESOLVED] Elevated Error Rates For FIFO Queues",
+      "date": "1587119196",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:26 AM PDT</span>&nbsp;We are investigating increased error rates for send and receive operations for FIFO Queues in the US-EAST-1 Region. All other queues are operating normally.\n</div><div><span class=\"yellowfg\"> 4:10 AM PDT</span>&nbsp;We have identified the cause of the increased error rates for send and receive operations for FIFO Queues in the US-EAST-1 Region and continue to work towards resolution. All other queues are operating normally and newly created FIFO queues will work without error.</div><div><span class=\"yellowfg\"> 5:05 AM PDT</span>&nbsp;We have identified the cause of the increased error rates for send and receive operations for FIFO Queues in the US-EAST-1 Region, and we are currently in the process of deploying the fix.</div><div><span class=\"yellowfg\"> 5:17 AM PDT</span>&nbsp;Between 2:01 AM PDT and 5:07 AM PDT we experienced increased error rates for send and receive operations for FIFO Queues in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "sqs-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Tokyo)",
+      "summary": "[RESOLVED] Alarm delays",
+      "date": "1587379127",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:38 AM PDT</span>&nbsp;ç¾åœ¨ã€AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®ã„ãã¤ã‹ã®ã‚¢ãƒ©ãƒ¼ãƒ ã®å‡¦ç†ã«ãŠã‘ã‚‹å¢—åŠ ã—ãŸãƒ¬ã‚¤ãƒ†ãƒ³ã‚·ãƒ¼ã«ã¤ã„ã¦èª¿æŸ»ã‚’è¡Œãªã£ã¦ãŠã‚Šã¾ã™ã€‚| We are investigating increased latencies for processing some alarms in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 4:23 AM PDT</span>&nbsp;AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®ã„ãã¤ã‹ã®ã‚¢ãƒ©ãƒ¼ãƒ å‡¦ç†ã®é…å»¶ã«ã¤ã„ã¦å¼•ãç¶šãèª¿æŸ»ã—ã¦ãŠã‚Šã¾ã™ã€‚å•é¡Œã®è§£æ±ºã«å‘ã‘ã¦å¯¾å¿œã—ã¦ãŠã‚Šã¾ã™ã€‚| We continue to investigate delays in processing some alarms in the AP-NORTHEAST-1 Region. We continue to work toward resolution. </div><div><span class=\"yellowfg\"> 6:18 AM PDT</span>&nbsp;4/20 19:03ã‹ã‚‰21:42(JST)ã«ã‹ã‘ã¦ AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã«ã¦ãŠå®¢æ§˜ãŒã„ãã¤ã‹ã®ã‚¢ãƒ©ãƒ¼ãƒ ã®é…å»¶ãŒç™ºç”Ÿã—ã¦ã„ãŸå¯èƒ½æ€§ãŒã”ã–ã„ã¾ã™ã€‚ç¾åœ¨ã§ã¯ã“ã¡ã‚‰ã®å•é¡Œã¯è§£æ±ºã•ã‚Œã€ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ãªçŠ¶æ…‹ã«å¾©æ—§ã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 3:03 AM and 5:42 AM PDT, customers may have experienced some delayed alarms in the AP-NORTHEAST-1 Region. We have resolved the issue and the service is operating normally. </div>",
+      "service": "cloudwatch-ap-northeast-1"
+    },
+    {
+      "service_name": "Amazon Simple Queue Service (Tokyo)",
+      "summary": "[RESOLVED] Elevated Error Rates",
+      "date": "1587379347",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:42 AM PDT</span>&nbsp;AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®é€ä¿¡ãŠã‚ˆã³å—ä¿¡æ“ä½œã«ãŠã‘ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®ä¸Šæ˜‡ã«ã¤ã„ã¦èª¿æŸ»ã‚’è¡Œãªã£ã¦ãŠã‚Šã¾ã™ã€‚ | We are investigating elevated error rates for send and receive operations in the AP-NORTHEAST-1 Region</div><div><span class=\"yellowfg\"> 4:21 AM PDT</span>&nbsp;AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®é€ä¿¡ãŠã‚ˆã³å—ä¿¡æ“ä½œã«ãŠã‘ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆä¸Šæ˜‡ã‚’èªè­˜ã—ã¦ãŠã‚Šã¾ã™ã€‚| We can confirm elevated error rates for send and receive operations in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 5:45 AM PDT</span>&nbsp;AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®é€ä¿¡ãŠã‚ˆã³å—ä¿¡æ“ä½œã«ãŠã‘ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆä¸Šæ˜‡ã®åŽŸå› ã‚’ç‰¹å®šã„ãŸã—ã¾ã—ãŸã€‚ç¾åœ¨å•é¡Œã®è»½æ¸›ã«å‘ã‘ã¦å¯¾å¿œã‚’é€²ã‚ã¦ãŠã‚Šã¾ã™ã€‚| We have identified the cause of the increased error rates for send and receive operations in the AP-NORTHEAST-1 Region. We are working towards mitigation.</div><div><span class=\"yellowfg\"> 6:28 AM PDT</span>&nbsp;4/20 18:56ã‹ã‚‰22:04(JST)ã«ã‹ã‘ã¦ AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®é€ä¿¡ãŠã‚ˆã³å—ä¿¡æ“ä½œã«ãŠã‘ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®ä¸Šæ˜‡ãŒç™ºç”Ÿã—ã¦ãŠã‚Šã¾ã—ãŸã€‚ç¾åœ¨ã§ã¯ã“ã¡ã‚‰ã®å•é¡Œã¯è§£æ±ºã•ã‚Œã€ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ãªçŠ¶æ…‹ã«å¾©æ—§ã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 2:56 AM and 6:04 AM PDT, we experienced elevated error rates for send and receive operations in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "sqs-ap-northeast-1"
+    },
+    {
+      "service_name": "AWS Lambda (Tokyo)",
+      "summary": "[RESOLVED] Elevated Error Rates",
+      "date": "1587379534",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:45 AM PDT</span>&nbsp;ç¾åœ¨ã€ AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®éžåŒæœŸå®Ÿè¡ŒãŠã‚ˆã³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ¬ãƒ¼ãƒ³ã¸ã®æ›¸ãè¾¼ã¿APIã«ãŠã‘ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®ä¸Šæ˜‡ã«ã¤ã„ã¦èª¿æŸ»ã‚’è¡Œãªã£ã¦ãŠã‚Šã¾ã™ã€‚ | We are investigating elevated error rates for asynchronous invocations and control plane APIs in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 6:42 AM PDT</span>&nbsp;AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®éžåŒæœŸå®Ÿè¡ŒãŠã‚ˆã³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ¬ãƒ¼ãƒ³ã¸ã®æ›¸ãè¾¼ã¿APIã«ãŠã‘ã‚‹ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®ä¸Šæ˜‡ã«ã¤ãã¾ã—ã¦ã€åŽŸå› ã‚’ç‰¹å®šã„ãŸã—ã¾ã—ãŸã€‚ç¾åœ¨ã§ã¯å¤§å¹…ãªã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®æ¸›å°‘ã‚’ç¢ºèªã§ãã¦ãŠã‚Šã€å®Œå…¨ãªå¾©æ—§ã®ãŸã‚ã«ç¶™ç¶šã—ã¦å¯¾å¿œã‚’è¡Œãªã£ã¦ãŠã‚Šã¾ã™ã€‚ | We identified the cause of the increased error rates for asynchronous invocations and write control plane APIs in the AP-NORTHEAST-1 Region. We are now seeing significantly reduced error rates, and continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 7:09 AM PDT</span>&nbsp;4/20 19:03ã‹ã‚‰22:50(JST)ã«ã‹ã‘ã¦ AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®éžåŒæœŸå®Ÿè¡ŒãŠã‚ˆã³ã‚³ãƒ³ãƒˆãƒ­ãƒ¼ãƒ«ãƒ—ãƒ¬ãƒ¼ãƒ³ã¸ã®æ›¸ãè¾¼ã¿APIã«ãŠã„ã¦ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã®ä¸Šæ˜‡ãŒç™ºç”Ÿã—ã¦ãŠã‚Šã¾ã—ãŸã€‚ç¾åœ¨ã§ã¯ã“ã¡ã‚‰ã®å•é¡Œã¯è§£æ±ºã•ã‚Œã€ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ãªçŠ¶æ…‹ã«å¾©æ—§ã—ã¦ãŠã‚Šã¾ã™ã€‚| Between 3:03 AM and 6:50 AM PDT, we we experienced increased error rates for asynchronous invocations and write control plane APIs in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "lambda-ap-northeast-1"
+    },
+    {
+      "service_name": "AWS CloudFormation (Tokyo)",
+      "summary": "[RESOLVED] Elevated Error Rates",
+      "date": "1587380986",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:09 AM PDT</span>&nbsp;ç¾åœ¨ AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã®ã™ã¹ã¦ã®ã‚¹ã‚¿ãƒƒã‚¯æ“ä½œã®ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆä¸Šæ˜‡ãŠã‚ˆã³é…å»¶ã«ã¤ã„ã¦èª¿æŸ»ã‚’è¡Œãªã£ã¦ãŠã‚Šã¾ã™ã€‚| We are investigating elevated error rates and latencies for all stack operations in the AP-NORTHEAST-1 Region.</div><div><span class=\"yellowfg\"> 6:24 AM PDT</span>&nbsp;/20 19:00ã‹ã‚‰21:40(JST)ã«ã‹ã‘ã¦ AP-NORTHEAST-1 ãƒªãƒ¼ã‚¸ãƒ§ãƒ³ã«ãŠã„ã¦ã‚¨ãƒ©ãƒ¼ãƒ¬ãƒ¼ãƒˆã¨ãƒ¬ã‚¤ãƒ†ãƒ³ã‚·ãƒ¼ã®ä¸Šæ˜‡ãŒç™ºç”Ÿã—ã¦ãŠã‚Šã¾ã—ãŸã€‚ç¾åœ¨ã§ã¯ã“ã¡ã‚‰ã®å•é¡Œã¯è§£æ±ºã•ã‚Œã€ã‚µãƒ¼ãƒ“ã‚¹ã¯æ­£å¸¸ãªçŠ¶æ…‹ã«å¾©æ—§ã—ã¦ãŠã‚Šã¾ã™ã€‚|Between 3:00 AM and 5:40 AM PDT we experienced increased error rates and latencies in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally. | Between 3:00 AM and 5:40 AM PDT we experienced increased error rates and latencies in the AP-NORTHEAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudformation-ap-northeast-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates and Latencies",
+      "date": "1587462325",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:45 AM PDT</span>&nbsp;We are investigating increased API error rates and latencies in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 3:16 AM PDT</span>&nbsp;Between 2:10 AM and 2:59 AM PDT we experienced increased API error rates and latencies in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudFront",
+      "summary": "[RESOLVED] Delays in Invalidation Change Times",
+      "date": "1587509850",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:57 PM PDT</span>&nbsp;We are investigating longer than usual invalidation change times for changes to CloudFront configurations. This issue is not impacting propagation times for changes to CloudFront configurations. End-user requests for content from our edge locations are not affected by this issue and are being served normally.</div><div><span class=\"yellowfg\"> 4:28 PM PDT</span>&nbsp;Between 2:26 PM and 4:20 PM PDT, we experienced delays in invalidation times for changes to CloudFront configurations. During this time end-user requests for content and propagation times for changes to CloudFront configurations were not affected. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudfront"
+    },
+    {
+      "service_name": "AWS CloudFormation (Oregon)",
+      "summary": "Increased Error Rates",
+      "date": "1588279630",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:47 PM PDT</span>&nbsp;We are investigating increased error rates and latencies for AWS CloudFormation stack operations in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 2:38 PM PDT</span>&nbsp;We have identified the root cause for the increased error rates and latencies for AWS CloudFormation stack operations in the US-WEST-2 Region and continue to work toward resolution.</div><div><span class=\"yellowfg\"> 3:10 PM PDT</span>&nbsp;Between 12:02 PM and 2:35 PM PDT we experienced increased error rates and latencies for AWS CloudFormation Stacks operations in the US-WEST-2 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudformation-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Container Service (N. California)",
+      "summary": "[RESOLVED] Elevated API Error Rates",
+      "date": "1589077890",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:31 PM PDT</span>&nbsp;We are investigating elevated API error rates and latencies in the US-WEST-1 Region.</div><div><span class=\"yellowfg\"> 8:13 PM PDT</span>&nbsp;We can confirm elevated API error rates and latencies in the US-WEST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 9:06 PM PDT</span>&nbsp;We have identified the cause of the elevated API error rates and latencies in the US-WEST-1 Region and continue working towards resolution. Running tasks are not impacted.</div><div><span class=\"yellowfg\"> 9:52 PM PDT</span>&nbsp;Between 6:53 PM and 9:37 PM PDT we experienced elevated API error rates and latencies in the US-WEST-1 Region. The issue has been resolved and the service is operating normally. Running tasks were not impacted.</div>",
+      "service": "ecs-us-west-1"
+    },
+    {
+      "service_name": "AWS Batch (N. California)",
+      "summary": "[RESOLVED]  Increased Delays in Job State Transition",
+      "date": "1589078329",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:38 PM PDT</span>&nbsp;We are investigating delay in job state transitions of AWS Batch Jobs in the US-WEST-1 Region. </div><div><span class=\"yellowfg\"> 8:32 PM PDT</span>&nbsp;We can confirm increased delay in job state transitions of AWS Batch Jobs in the US-WEST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 9:12 PM PDT</span>&nbsp;We have identified the cause of increased delays in job state transitions of AWS Batch Jobs in the US-WEST-1 Region and continue to work towards resolution.</div><div><span class=\"yellowfg\"> 9:55 PM PDT</span>&nbsp;Between 6:55 PM and 9:38PM PDT we experienced delayed job state transitions of AWS Batch Jobs in the US-WEST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "batch-us-west-1"
+    },
+    {
+      "service_name": "Amazon Elasticsearch Service (N. Virginia)",
+      "summary": "Increased indexing and query error rates for some VPC Domains",
+      "date": "1590072270",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:44 AM PDT</span>&nbsp;We are experiencing elevated error rates for indexing and query operations affecting a small number of VPC domains in the US-EAST-1 Region. We have identified the issue and working on recovery. </div><div><span class=\"yellowfg\"> 8:38 AM PDT</span>&nbsp;Between 2:55 AM and 8:30 AM PDT, we experienced elevated error rates for indexing and query operations affecting a small number of VPC domains in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "elasticsearch-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Container Registry (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates",
+      "date": "1590187729",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:48 PM PDT</span>&nbsp;Between 2:48 PM and 3:10 PM PDT Amazon ECR experienced certificate errors while using Docker clients in the US-WEST-2 Region. We have resolved the issue and the service is operating normally.</div>",
+      "service": "ecr-us-west-2"
+    },
+    {
+      "service_name": "Amazon Connect (Oregon)",
+      "summary": "[RESOLVED] Increased Error Rates ",
+      "date": "1591222848",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:20 PM PDT</span>&nbsp;We are investigating intermittent issues accessing the Amazon Connect web application in the US-WEST-2 Region.</div><div><span class=\"yellowfg\"> 3:51 PM PDT</span>&nbsp;We have identified the root cause of the issue causing intermittent issues accessing the Amazon Connect web application in the US-WEST-2 Region and continue working towards resolution.</div><div><span class=\"yellowfg\"> 4:40 PM PDT</span>&nbsp;We are beginning to see recovery for intermittent issues accessing the Amazon Connect web application in the US-WEST-2 Region. We continue to work toward full recovery.</div><div><span class=\"yellowfg\"> 5:53 PM PDT</span>&nbsp;Between 2:04 PM and 5:10 PM PDT some Amazon Connect customers experienced issues accessing the Amazon Connect web application in the US-WEST-2 Region. For a portion of that time, some users may have seen error messages when accessing the Amazon Connect web application. The issue has been resolved and the service is operating normally.</div>",
+      "service": "connect-us-west-2"
+    },
+    {
+      "service_name": "Amazon DynamoDB (Sao Paulo)",
+      "summary": "[RESOLVED] Increased 400 error rates ",
+      "date": "1591406183",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:16 PM PDT</span>&nbsp;We are investigating increased error rates for API requests talking to DynamoDB streams in the SA-EAST-1 Region.</div><div><span class=\"yellowfg\"> 6:34 PM PDT</span>&nbsp;We have identified the root cause of increased 400 error rate for API requests talking to DynamoDB streams in the SA-EAST-1 Region. Restarting applications talking to streams will resolve the issue while we continue to work towards resolution.</div><div><span class=\"yellowfg\"> 7:43 PM PDT</span>&nbsp;We are beginning to see recovery for the increased 400 error rate for API requests talking to DynamoDB streams in the SA-EAST-1 Region. Restarting applications talking to streams will resolve the issue while we continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 9:59 PM PDT</span>&nbsp;Between 3:50 PM and 9:53 PM PDT customers experienced increased 400 error rate for API requests talking to DynamoDB streams in the SA-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "dynamodb-sa-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Notification Service (N. Virginia)",
+      "summary": "[RESOLVED] Increased Error Rates for SMS Delivery",
+      "date": "1591822333",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:52 PM PDT</span>&nbsp;We are investigating elevated error rates and latencies when delivering SMS messages in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 2:33 PM PDT</span>&nbsp;We have identified the root cause of increased error rates and latencies when delivering SMS messages in the US-EAST-1 Region and are working towards resolution.</div><div><span class=\"yellowfg\"> 2:47 PM PDT</span>&nbsp;Between 9:10 AM and 2:04 PM PDT, we experienced elevated error rates and latencies when delivering SMS messages in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "sns-us-east-1"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased API Error Rates ",
+      "date": "1591943413",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:30 PM PDT</span>&nbsp;We are investigating increased error rates and latencies on AWS IAM administrative APIs with potential impact in multiple regions. IAM role creation is impacted. Other AWS services whose features require these actions may also be impacted. User authentications and authorizations are not impacted.</div><div><span class=\"yellowfg\">Jun 12, 12:03 AM PDT</span>&nbsp;We continue to investigate increased error rates and latencies on AWS IAM administrative APIs with potential impact in multiple regions. IAM role creation is impacted. Other AWS services like AWS CloudFormation whose features require these actions may also be impacted. User authentications and authorizations are not impacted.</div><div><span class=\"yellowfg\">Jun 12,  2:12 AM PDT</span>&nbsp;We have identified the root cause of the increased error rates and latencies on the AWS IAM CreateRole and CreateServiceLinkedRole APIs and are working towards resolution. Other AWS services such as AWS CloudFormation whose features require these actions may also be impacted. User authentications and authorizations are not impacted.</div><div><span class=\"yellowfg\">Jun 12,  3:30 AM PDT</span>&nbsp;We wanted to provide you with more details on the issue causing increased error rates and latencies on the AWS IAM CreateRole and CreateServiceLinkedRole APIs. While we have identified the root cause and are working towards resolution, with an issue like this, it is always difficult to provide an accurate ETA, but we expect to restore access to the CreateRole and CreateServiceLinkedRole APIs within the next several hours. We are working through the recovery process now and will continue to keep you updated if this ETA changes. IAM user authentications and authorizations are not impacted. Other AWS services like AWS CloudFormation whose features require these actions may also be impacted.</div><div><span class=\"yellowfg\">Jun 12,  4:27 AM PDT</span>&nbsp;We are beginning to see improvements as we continue to work towards recovery for the AWS IAM CreateRole and CreateServiceLinkedRole API Error Rates. Full resolution is estimated to take a few hours. Other AWS services such as AWS CloudFormation whose features require these actions will continue to be impacted. User authentications and authorizations are not impacted.</div><div><span class=\"yellowfg\">Jun 12,  5:20 AM PDT</span>&nbsp;We continue to see significant recovery for impacted customers for the increased error rates and latencies on the AWS IAM CreateRole and CreateServiceLinkedRoles APIs. We expect the residual error rates and latency to subside further over the next 2-3 hours. Other AWS services such as AWS CloudFormation whose features require these actions will see a similar overall reduction in errors during that time. User authentications and authorizations remain unimpacted.</div><div><span class=\"yellowfg\">Jun 12,  6:43 AM PDT</span>&nbsp;Between June 11 9:56 PM PDT and June 12 6:40 AM PDT, AWS IAM experienced increased error rates and latencies on the AWS IAM CreateRole and CreateServiceLinkedRoles APIs. The issue has been resolved and the service is operating normally.</div><div><span class=\"yellowfg\">Jun 12,  7:24 PM PDT</span>&nbsp;Although this issue has been resolved and the service is operating normally, if you have any questions or any operational issue with any of our services, please contact the AWS Support department via the AWS Support Center at <a href=\"https://console.aws.amazon.com/support/\">https://console.aws.amazon.com/support/</a>.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "AWS Organizations",
+      "summary": "[RESOLVED]  Increased API Error Rates",
+      "date": "1591948670",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">12:57 AM PDT</span>&nbsp;We are investigating increased error rates for account creation and invitations for Organizations with all features enabled. Other AWS services using Organizations service trust may also be impacted when activating new organizations or accounts.</div><div><span class=\"yellowfg\"> 2:13 AM PDT</span>&nbsp;We have identified the root cause of the increased error rates for account creation and invitations for Organizations with all features enabled and are working towards resolution. Other AWS services using Organizations service trust may also be impacted when activating new organizations or accounts.</div><div><span class=\"yellowfg\"> 5:38 AM PDT</span>&nbsp;We confirm significant recovery for account creation and invitations for Organizations with all features enabled. Other AWS services using Organizations service trust are also recovering when activating new organizations or accounts. In line with IAM, we expect the residual error rates and latency to subside further over the next 2-3 hours. </div><div><span class=\"yellowfg\"> 6:27 AM PDT</span>&nbsp;Between June 11 9:55 PM PDT and June 12 5:54 AM PDT, we experienced increased error rates for account creation and invitations for Organizations with all features enabled. Other AWS services using Organizations service trust may have also been impacted when activating new organizations or accounts. The issue has been resolved and the service is operating normally. If you have any questions or operational issue with any of our services, please contact the AWS Support department via the AWS Support Center at <a href=\"https://aws.amazon.com/support\">https://aws.amazon.com/support</a>.</div>",
+      "service": "organizations"
+    },
+    {
+      "service_name": "Amazon CloudWatch (Ireland)",
+      "summary": "Elevated API faults and latencies in EU-WEST-1.",
+      "date": "1592911198",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 4:19 AM PDT</span>&nbsp;We are investigating increased faults and latencies for CloudWatch APIs and metrics in the EU-WEST-1 Region. CloudWatch alarms may transition into \"INSUFFICIENT_DATA\" state if set on delayed metrics.</div><div><span class=\"yellowfg\"> 4:55 AM PDT</span>&nbsp;Between 3:13 AM and 4:37 AM PDT, some customers experienced elevated faults when calling CloudWatch APIs in the EU-WEST-1 Region. Some metrics were delayed, and CloudWatch alarms on delayed metrics transitioned into INSUFFICIENT_DATA state. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudwatch-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Oregon)",
+      "summary": "[RESOLVED] Increased Network Provisioning Latencies",
+      "date": "1593207544",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:39 PM PDT</span>&nbsp;We are experiencing delayed network provisioning times for newly launched instances and newly mapped Elastic IP addresses in a single Availability Zone in the US-WEST-2 Region. Existing instances are not affected by this issue. </div><div><span class=\"yellowfg\"> 3:04 PM PDT</span>&nbsp;We have resolved the issue affecting network provisioning times for newly launched instances and newly mapped Elastic IP addresses in a single Availability Zone in the US-WEST-2 Region. Existing instances were not affected by this issue. The issue is resolved and the service is operating normally.</div>",
+      "service": "ec2-us-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1594241886",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 1:58 PM PDT</span>&nbsp;We are investigating an increased API error rate for the DescribeInstances and DescribeImages APIs in the US-EAST-1 Region. </div><div><span class=\"yellowfg\"> 2:11 PM PDT</span>&nbsp;Between 1:22 PM and 2:06 PM PDT we experienced increased error rates and latencies for the DescribeInstances and DescribeImages APIs in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon CloudWatch (London)",
+      "summary": "[RESOLVED] Elevated latencies and Faults in EU-WEST-2",
+      "date": "1594383041",
+      "status": "2",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 5:10 AM PDT</span>&nbsp;We are investigating increased faults and latencies for CloudWatch APIs and metrics in the EU-WEST-2 Region.</div><div><span class=\"yellowfg\"> 5:24 AM PDT</span>&nbsp;We can confirm elevated API faults and some delayed metrics in EU-WEST-2 Region. We are actively working to resolve the issue.</div><div><span class=\"yellowfg\"> 6:04 AM PDT</span>&nbsp;We have identified the root cause for elevated API faults and latencies for the GetMetricData and GetMetricWidgetImage APIs in the EU-WEST-2 Region. We are actively working to resolve the issue and are starting to see recovery.</div><div><span class=\"yellowfg\"> 6:32 AM PDT</span>&nbsp;We have identified the root cause for elevated API faults and latencies for the GetMetricData and GetMetricWidgetImage APIs in the EU-WEST-2 Region. We can confirm significant recovery and are working actively to fully resolve the issue.</div><div><span class=\"yellowfg\"> 8:02 AM PDT</span>&nbsp;Between 4:07 AM and 7:28 AM PDT, customers experienced elevated API fault rates and latencies in the EU-WEST-2 Region. Some metrics were also delayed initially. We have resolved the issue and the service is operating normally.</div>",
+      "service": "cloudwatch-eu-west-2"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (Ireland)",
+      "summary": "[RESOLVED] Network connectivity issues",
+      "date": "1594732662",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:17 AM PDT</span>&nbsp;We are investigating network connectivity issues for some instances in a single Availability Zone in the EU-WEST-1 Region.\n\n</div><div><span class=\"yellowfg\"> 6:37 AM PDT</span>&nbsp;Network connectivity has been restored for the vast majority of the affected instances in a single Availability Zone in the EU-WEST-1 Region. Some EBS volumes within the affected Availability Zone are also experiencing degraded performance. We continue to work towards full recovery.</div><div><span class=\"yellowfg\"> 7:35 AM PDT</span>&nbsp;Starting at 5:35 AM PDT we experienced power and network connectivity issues for some instances, and degraded performance for some EBS volumes in a single Availability Zone in the EU-WEST-1 Region. By 6:00 AM PDT, power and networking connectivity had been restored for affected instances and by 6:31 AM PDT, degraded performance for affected EBS volumes had been resolved. By 7:08 AM PDT, the vast majority of affected instances had fully recovered. The small number of remaining instances are hosted on hardware which was adversely affected by the loss of power. While we will continue to work to recover all affected instances and volumes, for immediate recovery, we recommend replacing any remaining affected instances or volumes if possible. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-eu-west-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (US-East)",
+      "summary": "[RESOLVED] Increased error rates ",
+      "date": "1594851373",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:16 PM PDT</span>&nbsp;We are investigating increased API error rates and latencies in the US-GOV-EAST-1 Region.</div><div><span class=\"yellowfg\"> 3:47 PM PDT</span>&nbsp;Between 2:39 PM and 3:38 PM PDT we experienced increased API error rates and latencies in the US-GOV-EAST-1 Region. The issue has been resolved and the service is operating normally.\n</div>",
+      "service": "ec2-us-gov-east-1"
+    },
+    {
+      "service_name": "Amazon Simple Workflow Service (N. Virginia)",
+      "summary": "[RESOLVED] Elevated API and Workflow Execution Latencies ",
+      "date": "1595269046",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:17 AM PDT</span>&nbsp;Between 5:50 AM and 10:50 AM PDT, we experienced elevated API and workflow execution latencies in the US-EAST-1 Region. Some AWS services were also impacted during this period. The issue has been resolved and the services are operating normally.</div>",
+      "service": "swf-us-east-1"
+    },
+    {
+      "service_name": "AWS CloudFormation (N. Virginia)",
+      "summary": "[RESOLVED] Elevated Stack Latencies",
+      "date": "1595269919",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:32 AM PDT</span>&nbsp;Between 5:50 AM and 10:50 AM PDT, AWS CloudFormation experienced increased latencies when creating, updating, and deleting AWS CloudFormation stacks in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "cloudformation-us-east-1"
+    },
+    {
+      "service_name": "AWS Identity and Access Management",
+      "summary": "[RESOLVED] Increased API Error Rates",
+      "date": "1595327154",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 3:25 AM PDT</span>&nbsp;Between 12:02 AM and 2:35 AM PDT AWS customers experienced increased error rates while calling the IAM assume role, get session token and other APIs with the long term credentials. As of 2:35 AM PDT, we are fully recovered and the issue is resolved now. Other AWS services such as AWS CloudFormation whose features require these actions experienced similar impact.</div>",
+      "service": "iam"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED] Increased API error rates",
+      "date": "1595527657",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\">11:07 AM PDT</span>&nbsp;We are investigating increased API error rates in the US-EAST-1 Region.</div><div><span class=\"yellowfg\">12:23 PM PDT</span>&nbsp;We're seeing some recovery for the increased EC2 API error rates and latencies in the US-EAST-1 Region, but some API requests may see a \"request limit exceeded\" responses as we work towards full recovery. Some Instance status checks for newly launched EC2 instances in a single Availability Zone may return insufficient-data for their instance and system status checks. Connectivity to existing EC2 instances is not affected by this event.</div><div><span class=\"yellowfg\">12:57 PM PDT</span>&nbsp;We're seeing recovery for the increased EC2 API error rates and latencies in the US-EAST-1 Region, but some API requests may still see \"request limit exceeded\" responses as we continue to work on this issue. Instance status checks for newly launched EC2 instances are no longer returning insufficient-data for their instance and system status checks. Connectivity to existing EC2 instances is not affected by this event.</div><div><span class=\"yellowfg\"> 2:03 PM PDT</span>&nbsp;We're seeing recovery for the increased EC2 API error rates and latencies in the US-EAST-1 Region and a smaller number of API requests are now returning \"request limit exceeded\" responses as we continue to work on this issue. Instance status checks for newly launched EC2 instances are no longer returning insufficient-data for their instance and system status checks. Connectivity to existing EC2 instances is not affected by this event. </div><div><span class=\"yellowfg\"> 2:52 PM PDT</span>&nbsp;We're seeing recovery for the increased EC2 API error rates and latencies in the US-EAST-1 Region. The API DescribeVolumes may return \"request limit exceeded\" responses as we continue to work on this issue. Instance status checks for newly launched EC2 instances are no longer returning insufficient-data for their instance and system status checks. Connectivity to existing EC2 instances is not affected by this event.</div><div><span class=\"yellowfg\"> 3:56 PM PDT</span>&nbsp;We are seeing recovery for increased EC2 API error rates and latencies with the exception of small number of DescribeVolumes calls which may return \"request limit exceeded\" responses as we continue to work on this issue. Instance status checks for EC2 instances have recovered. Connectivity to existing EC2 instances is not affected by this event.</div><div><span class=\"yellowfg\"> 5:02 PM PDT</span>&nbsp;We have resolved the issue causing periods of increased EC2 API error rates and latencies as well as insufficient-data results for EC2 instance and system status checks in the US-EAST-1 Region. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    },
+    {
+      "service_name": "Amazon Route 53 Resolver (N. Virginia)",
+      "summary": "[RESOLVED] DNS Propagation Delays for EC2 Instance Names ",
+      "date": "1595861956",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 7:59 AM PDT</span>&nbsp;We are investigating VPC DNS propagation delays in the US-EAST-1 Region. This issue only affects resolution of newly launched EC2 instances that rely on public to private IP DNS mapping, such as newly launched Relational Database Service (RDS) instances. It will also affect configuration changes to VPC peering associations. We have identified root cause and are actively working towards identifying a mitigation.</div><div><span class=\"yellowfg\"> 8:24 AM PDT</span>&nbsp;We have identified a mitigation path and are working towards resolution. This issue only affects resolution of newly launched EC2 instances that rely on public to private IP DNS mapping, such as newly launched Relational Database Service (RDS) instances from within a VPC. It will also affect configuration changes to VPC peering associations.</div><div><span class=\"yellowfg\"> 9:26 AM PDT</span>&nbsp;We have confirmed our mitigation is correct, and are actively deploying it. Recovery is in progress now.</div><div><span class=\"yellowfg\">10:43 AM PDT</span>&nbsp;We are continuing to deploy the mitigation to this issue. Impact is limited to workloads that require resolving public DNS names to private IP addresses for instances launched in a newly created VPC, as well as reverse DNS lookups from within a newly created VPC. Resolution of all instances in existing VPCs continue to work normally.</div><div><span class=\"yellowfg\">12:04 PM PDT</span>&nbsp;We are continuing to deploy the mitigation to this issue. Customers may see partial recovery as we work towards full resolution.</div><div><span class=\"yellowfg\">12:57 PM PDT</span>&nbsp;Mitigation efforts continue, and customers should see increased recovery as we work towards full resolution.</div><div><span class=\"yellowfg\"> 1:41 PM PDT</span>&nbsp;Between 6:32 AM and 1:35 PM PDT, customers experienced issues resolving newly created public EC2 instance names to private IPs within newly created VPCs in the US-EAST-1 Region. Creation of new Route 53 Resolver Endpoints was also delayed during this time. Newly created instances within existing VPCs resolved normally, and all other DNS functionality worked normally in all VPCs during this time. The issue has been resolved and all DNS queries are being answered normally.</div>",
+      "service": "route53resolver-us-east-1"
+    },
+    {
+      "service_name": "Amazon Route 53 Resolver (N. Virginia)",
+      "summary": "[RESOLVED] Single AZ Intermittent DNS Lookup",
+      "date": "1595927486",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 2:11 AM PDT</span>&nbsp;We are investigating an increase in DNS lookup failures from EC2 instances in a single Availability Zone in the US-EAST-1 Region.</div><div><span class=\"yellowfg\"> 2:57 AM PDT</span>&nbsp;We are continuing to investigate increased DNS resolution errors from EC2 instances in a single Availability Zone of the US-EAST-1 Region. This could also impact functionality of other services that use EC2, such as App Mesh, Cloud9, ElasticSearch, EMR, Managed Blockchain, SageMaker, Transfer for SFTP, WorkMail, and Glue.</div><div><span class=\"yellowfg\"> 3:44 AM PDT</span>&nbsp;We are implementing a mitigation to the increased DNS resolution errors from EC2 instances in a single Availability Zone in the US-EAST-1 Region, and are starting to see recovery. This issue could also impact functionality of other services that use EC2, such as App Mesh, Cloud9, ElasticSearch, EMR, Managed Blockchain, SageMaker, Transfer for SFTP, WorkMail, RDS, and Glue.</div><div><span class=\"yellowfg\"> 4:19 AM PDT</span>&nbsp;DNS resolution failures in a single Availability Zone in the US-EAST-1 Region have largely been mitigated, and we are continuing to work towards full mitigation. </div><div><span class=\"yellowfg\"> 4:37 AM PDT</span>&nbsp;Between 1:22 AM and 4:13 AM PDT, customers experienced an increase in DNS resolution errors from EC2 instances in a single Availability Zone of the US-EAST-1 Region. This could have also impacted functionality of other services that use EC2, such as RDS, SageMaker, EMR, WorkMail, MSK, AWS IoT Analytics Service, Amazon ElasticSearch, Cloud9, AppMesh, Amazon Managed Blockchain, Glue, and AWS Transfer. The issue has been resolved and all DNS queries are being answered normally.</div>",
+      "service": "route53resolver-us-east-1"
+    },
+    {
+      "service_name": "Amazon Elastic Compute Cloud (N. Virginia)",
+      "summary": "[RESOLVED]  Increased API Error Rates ",
+      "date": "1596028900",
+      "status": "1",
+      "details": "",
+      "description": "<div><span class=\"yellowfg\"> 6:21 AM PDT</span>&nbsp;We have identified the cause of the increased API error rates in a single Availability Zone in the US-EAST-1 Region and continue working towards resolution. Customers experiencing errors launching new EC2 instances may attempt to launch their EC2 instances in another Availability Zone. Existing running instances are unaffected.</div><div><span class=\"yellowfg\"> 8:23 AM PDT</span>&nbsp;We want to provide more information on this issue and progress toward resolution. At 5:18 AM PDT, we began experiencing increased API errors that originated from one of our EC2 sub-systems that is responsible for managing EC2 instances. This resulted in increased error rates for some EC2 APIs and affected new instance launches in a Single Availability Zone. The root cause of the error rates affecting the sub-system has been identified and engineers are currently working on resolving the issue. Existing instances remain unaffected by this issue.</div><div><span class=\"yellowfg\">10:19 AM PDT</span>&nbsp;We have deployed a fix to the impacted EC2 sub-system causing increased API error rates and new instance launch failures in a Single Availability zone in the US-EAST-1 Region and are beginning to see recovery. We continue to work towards full resolution. Existing instances remain unaffected by this issue.\n</div><div><span class=\"yellowfg\">10:52 AM PDT</span>&nbsp;Between 5:18 AM and 10:25 AM PDT we experienced increased error rates for some EC2 APIs and new instance launches in a Single Availability Zone in the US-EAST-1 region. Existing instances were unaffected. We are working to address API errors affecting a small number of EBS volumes as a result of this issue. The issue has been resolved and the service is operating normally.</div>",
+      "service": "ec2-us-east-1"
+    }
+  ],
+  "current": []
+}

--- a/src/api/fetchers/aws.js
+++ b/src/api/fetchers/aws.js
@@ -1,6 +1,25 @@
-const aws = module.exports = {
-  name: 'aws',
-  hasRegions: true
+const aws = module.exports = {}
+const config = require('../../../config')
+const transformer = require('../transformers/aws.js')
+const tiny = require('tiny-json-http')
+
+aws._rawFetchIssues = async () => {
+  console.log(config.aws.fetchUrl)
+  return tiny.get({ url: config.aws.fetchUrl })
 }
 
-aws.getName = () => { return 'aws' }
+aws._downDetectorFetch = async () => {
+  const url = config.global.downDetectorUrl.replace('%SERVICE_NAME%', config.aws.downDetectorIdentifier)
+  return tiny.get({ url })
+}
+
+aws.fetch = async () => {
+  console.log('aws fetching')
+  let r
+  try {
+    r = await aws._rawFetchIssues()
+  } catch (e) {
+    console.log('???', e)
+  }
+  console.log(r && r.body || '...')
+}

--- a/src/api/fetchers/aws.js
+++ b/src/api/fetchers/aws.js
@@ -1,25 +1,25 @@
 const aws = module.exports = {}
 const config = require('../../../config')
 const transformer = require('../transformers/aws.js')
-const tiny = require('tiny-json-http')
+const simpleFetch = require('../../lib/simpleFetch.js')
 
 aws._rawFetchIssues = async () => {
-  console.log(config.aws.fetchUrl)
-  return tiny.get({ url: config.aws.fetchUrl })
+  return simpleFetch.json(
+    config.aws.fetchUrl,
+    'aws raw issues fetch'
+  )
 }
 
 aws._downDetectorFetch = async () => {
   const url = config.global.downDetectorUrl.replace('%SERVICE_NAME%', config.aws.downDetectorIdentifier)
-  return tiny.get({ url })
+  return simpleFetch.html(
+    url,
+    'aws down detector fetch'
+  )
 }
 
 aws.fetch = async () => {
-  console.log('aws fetching')
-  let r
-  try {
-    r = await aws._rawFetchIssues()
-  } catch (e) {
-    console.log('???', e)
-  }
-  console.log(r && r.body || '...')
+   console.log((await aws._rawFetchIssues()))
+  //  const r = await aws._downDetectorFetch()
+  //  console.log(r)
 }

--- a/src/api/fetchers/gcloud.js
+++ b/src/api/fetchers/gcloud.js
@@ -4,7 +4,7 @@ const transformer = require('../transformers/gcloud.js')
 const tiny = require('tiny-json-http')
 
 gcloud._rawFetchIssues = async () => {
-  return tiny.get({ url: config.fetchUrl })
+  return tiny.get({ url: config.gcloud.fetchUrl })
 }
 
 // Temporarily suspending tweet volume fetching -

--- a/src/api/fetchers/gcloud.js
+++ b/src/api/fetchers/gcloud.js
@@ -1,10 +1,13 @@
 const gcloud = module.exports = {}
 const config = require('../../../config')
 const transformer = require('../transformers/gcloud.js')
-const tiny = require('tiny-json-http')
+const simpleFetch = require('../../lib/simpleFetch.js')
 
 gcloud._rawFetchIssues = async () => {
-  return tiny.get({ url: config.gcloud.fetchUrl })
+  return simpleFetch.json(
+    config.gcloud.fetchUrl,
+    'gcloud raw issues fetch'
+  )
 }
 
 // Temporarily suspending tweet volume fetching -
@@ -12,9 +15,13 @@ gcloud._rawFetchIssues = async () => {
 // so will consider just embedding a recent tweet window into appropriate locations..
 // probable if people check a specific service instead of the overview
 gcloud._tweetVolumeFetch = async () => {}
+
 gcloud._downDetectorFetch = async () => {
   const url = config.global.downDetectorUrl.replace('%SERVICE_NAME%', config.gcloud.downDetectorIdentifier)
-  return tiny.get({ url })
+  return simpleFetch.html(
+    url,
+    'gcloud down detector fetch'
+  )
   /*
   console.log('No problems', r.body.includes('No problems at'))
   console.log('Possible problems', r.body.includes('Possible problems at'))
@@ -26,7 +33,7 @@ gcloud._downDetectorFetch = async () => {
 gcloud.fetch = async () => {
   // Check cache for a transformed object, return it if found
   // Otherwise fetch+transform, cache(1min ttl) and return
-  // console.log((await gcloud._rawFetchIssues()).body)
+  // console.log((await gcloud._rawFetchIssues()))
   const r = await gcloud._downDetectorFetch()
-  console.log(r.body)
+  console.log(r)
 }

--- a/src/api/run.js
+++ b/src/api/run.js
@@ -2,5 +2,5 @@ const x = require('./fetchers')
 
 ;(async () => {
   console.log('Running...')
-  await x.gcloud.fetch()
+  await x.aws.fetch()
 })()

--- a/src/api/transformers/aws.js
+++ b/src/api/transformers/aws.js
@@ -1,0 +1,5 @@
+const aws = module.exports = {}
+
+aws.overview = () => {
+  
+}

--- a/src/lib/simpleFetch.js
+++ b/src/lib/simpleFetch.js
@@ -1,0 +1,26 @@
+const simpleFetch = module.exports = {}
+const fetch = require('node-fetch')
+
+simpleFetch._handle = async (url, description, bodyFunction) => {
+  if (!url) {
+    console.warn('simpleFetch.json had no url', url)
+    return null
+  }
+  let fetchResult
+  try {
+    fetchResult = await fetch(url)
+    fetchResult = await fetchResult[bodyFunction]()
+  } catch (e) {
+    console.warn(`simpleFetch.json failed to get/decode data: ${description}`, e)
+    fetchResult = null
+  }
+  return fetchResult
+}
+
+simpleFetch.json = async (url, description) => {
+  return simpleFetch._handle(url, description, 'json')
+}
+
+simpleFetch.html = async (url, description) => {
+  return simpleFetch._handle(url, description, 'text')
+}


### PR DESCRIPTION
This PR adds support for the fetching of AWS statuses.

It also tidies up the use of tiny-http-json in favour of node-fetch module since tiny-http-json struggled with AWS' JSON, potentially due to content security policies. 

This included adding a simpleFetch wrapper that handles json/html fetching in a simple wrapper to avoid re-writing fetch try/catch boiler plate