### PR TITLE
Transformer for AWS incident data

### DIFF
--- a/config/aws.js
+++ b/config/aws.js
@@ -8,5 +8,32 @@ module.exports = {
   historicalStatusPageUrl: 'https://aws.amazon.com/premiumsupport/technology/pes/',
   incidentDirectUriBase: '',
   fetchUrl: 'https://status.aws.amazon.com/data.json',
-  downDetectorIdentifier: 'aws-amazon-web-services'
+  downDetectorIdentifier: 'aws-amazon-web-services',
+  knownRegions: [
+    'us-east-2',
+    'us-east-1',
+    'us-west-1',
+    'us-west-2',
+    'af-south-1',
+    'ap-east-1',
+    'ap-south-1',
+    'ap-northeast-3',
+    'ap-northeast-2',
+    'ap-southeast-1',
+    'ap-southeast-2',
+    'ap-northeast-1',
+    'ca-central-1',
+    'cn-north-1',
+    'cn-northwest-1',
+    'eu-central-1',
+    'eu-west-1',
+    'eu-west-2',
+    'eu-south-1',
+    'eu-west-3',
+    'eu-north-1',
+    'me-south-1',
+    'sa-east-1',
+    'us-gov-east-1',
+    'us-gov-west-1'
+  ]
 }

--- a/config/aws.js
+++ b/config/aws.js
@@ -1,7 +1,12 @@
 module.exports = {
   providerKey: 'aws',
   providerName: 'Amazon Web Services',
+  providerLogo: '//',
+  labels: [],
   hasRegions: true,
+  statusPageUrl: 'https://status.aws.amazon.com/',
+  historicalStatusPageUrl: 'https://aws.amazon.com/premiumsupport/technology/pes/',
+  incidentDirectUriBase: '',
   fetchUrl: 'https://status.aws.amazon.com/data.json',
   downDetectorIdentifier: 'aws-amazon-web-services'
 }

--- a/src/api/fetchers/aws.js
+++ b/src/api/fetchers/aws.js
@@ -19,7 +19,6 @@ aws._downDetectorFetch = async () => {
 }
 
 aws.fetch = async () => {
-  const [r1, r2] = await Promise.allSettled([aws._rawFetchIssues(), aws._downDetectorFetch()])
-  console.log('r1', r1)
-  console.log('r2', r2)
+  const [raw, ddData] = await Promise.allSettled([aws._rawFetchIssues(), aws._downDetectorFetch()])
+  return transformer.v1(raw.value, ddData.value)
 }

--- a/src/api/run.js
+++ b/src/api/run.js
@@ -1,7 +1,10 @@
 const x = require('./fetchers')
+const a = require('.././api/examples/aws-maybe-json?.json')
 
 ;(async () => {
   console.log('Running...')
   const r = await x.gcloud.fetch()
-  console.log(r)
+  console.log(JSON.stringify(r, null, 2))
+  // const allServiceNames = [...new Set(a.archive.map(x => x.service))]
+  // console.log(JSON.stringify(allServiceNames, null, 2))
 })()

--- a/src/api/transformers/aws.js
+++ b/src/api/transformers/aws.js
@@ -13,7 +13,7 @@ aws._isOngoing = (incident) => {
   return isRelevant && !looksResolved
 }
 
-aws._isRecent = (incident) => moment().subtract(2, 'days').isBefore(moment(parseInt(incident.date, 10)))
+aws._isRecent = (incident) => moment().subtract(2, 'days').isBefore(moment.unix(incident.date))
 
 aws._splitIncidents = (incidents) => {
   let ongoing = []
@@ -48,7 +48,7 @@ aws._transformIncident = (incident) => {
       key: incident.service,
       name: incident.service_name
     },
-    affectedRegions: [], // Can calculate from service ... need to check all values
+    affectedRegions: config.knownRegions.filter(region => incident.service.includes(region)),
     shortSummary: incident.summary,
     updates: aws._extractUpdates(incident.description),
     directUri: null

--- a/src/api/transformers/shared.js
+++ b/src/api/transformers/shared.js
@@ -1,0 +1,33 @@
+const shared = module.exports = {}
+
+shared._uiMeta = (affectedRegions, config) => {
+  const relevantKeys = [
+    'providerKey',
+    'providerName',
+    'providerLogo',
+    'labels',
+    'statusPageUrl',
+    'historicalStatusPageUrl'
+  ]
+  return {
+    ...Object.fromEntries(Object.entries(config).filter(c => relevantKeys.includes(c[0]))),
+    affectedRegions: affectedRegions || []
+  }
+}
+
+shared._splitIncidents = (incidents, ongoingClassifierFunc, recentClassifierFunc) => {
+  if (!incidents || !Array.isArray(incidents)) return [null, null]
+  let ongoing = []
+  let recent = []
+  for (let i = 0; i < incidents.length; i++) {
+    if (ongoingClassifierFunc(incidents[i])) {
+      ongoing.push(incidents[i])
+      break
+    }
+    if (recentClassifierFunc(incidents[i])) {
+      recent.push(incidents[i])
+      break
+    }
+  }
+  return [ongoing, recent]
+}


### PR DESCRIPTION
This PR adds support for transforming AWS incidents JSON into usable data.

It also adds a shared transformer for elements that seemed to be duplicated. A next action will be to go and convert the existing gcloud transformer to make use of the shared module to reduce redundant code. 