### PR TITLE
Remove redundant gcloud code, replace with shared module

### DIFF
--- a/src/api/transformers/gcloud.js
+++ b/src/api/transformers/gcloud.js
@@ -2,41 +2,14 @@ const gcloud = module.exports = {}
 const moment = require('moment')
 const config = require('../../../config').gcloud
 const ddParser = require('../../lib/downDetectorParser.js')
+const shared = require('./shared.js')
 
-gcloud._uiMeta = (affectedRegions) => {
-  const relevantKeys = [
-    'providerKey',
-    'providerName',
-    'providerLogo',
-    'labels',
-    'statusPageUrl',
-    'historicalStatusPageUrl'
-  ]
-  return {
-    ...Object.fromEntries(Object.entries(config).filter(c => relevantKeys.includes(c[0]))),
-    affectedRegions: affectedRegions || []
-  }
-}
+gcloud._uiMeta = (affectedRegions) => shared._uiMeta(affectedRegions, config)
 
 gcloud._isOngoing = (incident) => incident.begin && (!incident.end || incident.end === null)
 gcloud._isRecent = (incident) => moment().subtract(2, 'days').isBefore(moment(incident.end))
 
-gcloud._splitIncidents = (incidents) => {
-  if (!incidents || !Array.isArray(incidents)) return [null, null]
-  let ongoing = []
-  let recent = []
-  for (let i = 0; i < incidents.length; i++) {
-    if (gcloud._isOngoing(incidents[i])) {
-      ongoing.push(incidents[i])
-      continue
-    }
-    if (gcloud._isRecent(incidents[i])) {
-      recent.push(incidents[i])
-      continue
-    }
-  }
-  return [ongoing, recent]
-}
+gcloud._splitIncidents = (incidents) => shared._splitIncidents(incidents, gcloud._isOngoing, gcloud._isRecent)
 
 gcloud._transformIncident = (incident) => {
   if (!incident) return null

--- a/src/api/transformers/shared.js
+++ b/src/api/transformers/shared.js
@@ -15,6 +15,10 @@ shared._uiMeta = (affectedRegions, config) => {
   }
 }
 
+/*
+  Now only used by gcloud as AWS ended up being finnicky. Will keep for now but consider
+  moving back to unique functions if future transformers can't make use of it also.
+*/
 shared._splitIncidents = (incidents, ongoingClassifierFunc, recentClassifierFunc) => {
   if (!incidents || !Array.isArray(incidents)) return [null, null]
   let ongoing = []
@@ -22,11 +26,11 @@ shared._splitIncidents = (incidents, ongoingClassifierFunc, recentClassifierFunc
   for (let i = 0; i < incidents.length; i++) {
     if (ongoingClassifierFunc(incidents[i])) {
       ongoing.push(incidents[i])
-      break
+      continue
     }
     if (recentClassifierFunc(incidents[i])) {
       recent.push(incidents[i])
-      break
+      continue
     }
   }
   return [ongoing, recent]


### PR DESCRIPTION
Gcloud was written first at a time where I didn't realise how re-usable some of the code would be. This is a quick refactor work to make use of a shared module for some of the predictable functions. 