### PR TITLE
Remove affectedRegions from uiMeta

### DIFF
--- a/src/api/transformers/aws.js
+++ b/src/api/transformers/aws.js
@@ -5,7 +5,7 @@ const ddParser = require('../../lib/downDetectorParser.js')
 const shared = require('./shared.js')
 const { parse } = require('node-html-parser')
 
-aws._uiMeta = (affectedRegions) => shared._uiMeta(affectedRegions, config)
+aws._uiMeta = shared._uiMeta
 
 aws._isOngoing = (incident) => {
   const looksResolved = incident.summary.trim().startsWith('[RESOLVED]')
@@ -59,7 +59,7 @@ aws.v1 = (raw, ddData) => {
   const [ongoing, recent] = aws._splitIncidents(raw)
 
   return {
-    uiMeta: aws._uiMeta(),
+    uiMeta: aws._uiMeta(config),
     ongoingIncidents: ongoing && ongoing.map(aws._transformIncident) || null,
     recentIncidents: recent && recent.map(aws._transformIncident) || null,
     downDetectorData: ddParser.jsonOverview(ddData)

--- a/src/api/transformers/gcloud.js
+++ b/src/api/transformers/gcloud.js
@@ -4,7 +4,7 @@ const config = require('../../../config').gcloud
 const ddParser = require('../../lib/downDetectorParser.js')
 const shared = require('./shared.js')
 
-gcloud._uiMeta = (affectedRegions) => shared._uiMeta(affectedRegions, config)
+gcloud._uiMeta = shared._uiMeta
 
 gcloud._isOngoing = (incident) => incident.begin && (!incident.end || incident.end === null)
 gcloud._isRecent = (incident) => moment().subtract(2, 'days').isBefore(moment(incident.end))
@@ -32,7 +32,7 @@ gcloud.v1 = (raw, ddData) => {
   const [ongoing, recent] = gcloud._splitIncidents(raw)
 
   return {
-    uiMeta: gcloud._uiMeta(),
+    uiMeta: gcloud._uiMeta(config),
     ongoingIncidents: ongoing && ongoing.map(gcloud._transformIncident) || null,
     recentIncidents: recent && recent.map(gcloud._transformIncident) || null,
     downDetectorData: ddParser.jsonOverview(ddData)

--- a/src/api/transformers/shared.js
+++ b/src/api/transformers/shared.js
@@ -1,6 +1,6 @@
 const shared = module.exports = {}
 
-shared._uiMeta = (affectedRegions, config) => {
+shared._uiMeta = (config) => {
   const relevantKeys = [
     'providerKey',
     'providerName',
@@ -10,8 +10,7 @@ shared._uiMeta = (affectedRegions, config) => {
     'historicalStatusPageUrl'
   ]
   return {
-    ...Object.fromEntries(Object.entries(config).filter(c => relevantKeys.includes(c[0]))),
-    affectedRegions: affectedRegions || []
+    ...Object.fromEntries(Object.entries(config).filter(c => relevantKeys.includes(c[0])))
   }
 }
 


### PR DESCRIPTION
The initial design of uiMeta included affectedRegions, but this doesn't make complete sense when there are more than 1 ongoing incidents. The regions are incident specific and should only be stored against each incident.

This PR corrects that by ditching affectedRegions from uiMeta. 

(Addresses issue #6)