### PR TITLE
Optimise font awesome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aduh95/preact-fontawesome": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@aduh95/preact-fontawesome/-/preact-fontawesome-0.1.5.tgz",
+      "integrity": "sha512-oysDedjLeyM9WMHCEFAu1VjLsOzh2R7APkskY9qbNZLI0YWE+dRMIBVzlraHXEfkkOsMc5v0xIzQzMLX1xGDdg==",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -1142,10 +1150,31 @@
         "minimist": "^1.2.0"
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
+      "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg=="
+    },
     "@fortawesome/fontawesome-free": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",
       "integrity": "sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz",
+      "integrity": "sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz",
+      "integrity": "sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
+      }
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1700,6 +1729,11 @@
           "dev": true
         }
       }
+    },
+    "@versesforlife/preact-fontawesome": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@versesforlife/preact-fontawesome/-/preact-fontawesome-1.0.0.tgz",
+      "integrity": "sha512-1vW3ewPu7urtpMJLUFCbYbP1F+UK5ASRecEjJzQ6lYHYsT0iDW8BVEgGj3/UkobZiZoNT/rrgMjiZwkl6+bSew=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -8772,8 +8806,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -9142,7 +9175,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -11836,7 +11868,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -12072,8 +12103,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-refresh": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/YcleptJohn/statuses#readme",
   "dependencies": {
     "@aduh95/preact-fontawesome": "0.1.5",
-    "@fortawesome/fontawesome-free": "^5.14.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "bulma": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
   },
   "homepage": "https://github.com/YcleptJohn/statuses#readme",
   "dependencies": {
+    "@aduh95/preact-fontawesome": "0.1.5",
     "@fortawesome/fontawesome-free": "^5.14.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.30",
+    "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "bulma": "^0.9.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
@@ -61,7 +64,7 @@
       "<rootDir>/tests/__mocks__/setupTests.js"
     ]
   },
-  "engines" :{
+  "engines": {
     "node": ">=12.0.0"
   }
 }

--- a/src/ui/components/card/index.js
+++ b/src/ui/components/card/index.js
@@ -4,6 +4,8 @@ import ModularCssHelper from '../../lib/ModularCssHelper.js';
 import IncidentsSummary from '../incidentsSummary';
 import DownDetectorSummary from '../downDetectorSummary';
 import statuses from '../../lib/statusConstants.js';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
@@ -19,7 +21,7 @@ const Card = ({ meta, status, data }) => {
         <header class={c.ss(`card-header ${headerColour}`)}>
           <p class={c.ss('card-header-title is-centered')}>
             {meta.providerName}
-            {status === statuses.IN_PROGRESS && <i class={c.ss('fas fa-circle-notch fa-spin fa-fw has-text-primary ml-2')} />}
+            {status === statuses.IN_PROGRESS && <FontAwesomeIcon icon={faCircleNotch} spin fixedWidth className={c.ss('has-text-primary ml-2')} />}
           </p>
         </header>
         <div class={c.ss('card-content')}>

--- a/src/ui/components/collapsibleSection/index.js
+++ b/src/ui/components/collapsibleSection/index.js
@@ -2,6 +2,8 @@ import { h } from 'preact';
 import style from './style.scss';
 import ModularCssHelper from '../../lib/ModularCssHelper.js';
 import { useState } from 'preact/hooks';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faChevronRight, faChevronDown, faPlus, faMinus } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
@@ -28,8 +30,8 @@ const CollapsibleSection = ({ id, title, subTitle, isCompact, children }) => {
             <span class={c.ss('compact-collapsible-header-icon')}>
               <span class={c.ss('icon')}>
                 {!isCollapsed
-                ? <i class='fas fa-chevron-right' />
-                : <i class='fas fa-chevron-down' />}
+                ? <FontAwesomeIcon icon={faChevronRight} />
+                : <FontAwesomeIcon icon={faChevronDown} />}
               </span>
             </span>
             {title}
@@ -50,8 +52,8 @@ const CollapsibleSection = ({ id, title, subTitle, isCompact, children }) => {
           <span class={c.ss('collapsible-header-icon')}>
             <span class={c.ss('icon has-text-primary-dark')}>
               {!isCollapsed
-              ? <i class='fas fa-plus' />
-              : <i class='fas fa-minus' />}
+              ? <FontAwesomeIcon icon={faPlus} />
+              : <FontAwesomeIcon icon={faMinus} />}
             </span>
           </span>
         </h5>

--- a/src/ui/components/detailedIncident/index.js
+++ b/src/ui/components/detailedIncident/index.js
@@ -3,6 +3,8 @@ import style from './style.scss';
 import ModularCssHelper from '../../lib/ModularCssHelper.js';
 import Time from '../time.js';
 import { metaFields } from '../../lib/IncidentMetaFields.js';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faLink } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
@@ -18,7 +20,7 @@ const DetailedIncident = ({ incident, type, index, isLastChild }) => {
           return (
             <p>
               {field.uiIcon && <span class={c.ss('icon has-text-primary-dark')}>
-                <i class={`fas ${field.uiIcon}`} />
+                <FontAwesomeIcon icon={field.uiIcon} />
               </span>}
               <span class={c.ss('has-text-weight-bold')}>{field.uiText}</span>
               &nbsp;-&nbsp;
@@ -36,7 +38,7 @@ const DetailedIncident = ({ incident, type, index, isLastChild }) => {
         })}
         {incident.directUri && <a href={incident.directUri} target='_blank' rel='noreferrer'>
           <span class={c.ss('icon has-text-primary-dark')}>
-            <i class={`fas fa-link`} />
+            <FontAwesomeIcon icon={faLink} />
           </span>
           <span class={c.ss('has-text-weight-bold has-text-grey-dark')}>Incident Page</span>
         </a>}

--- a/src/ui/components/detailedPanel/index.js
+++ b/src/ui/components/detailedPanel/index.js
@@ -3,6 +3,8 @@ import style from './style.scss';
 import ModularCssHelper from '../../lib/ModularCssHelper.js';
 import DetailedPanelBody from '../detailedPanelBody';
 import statuses from '../../lib/statusConstants.js';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faArrowLeft, faCircleNotch } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
@@ -18,13 +20,13 @@ const DetailedPanel = (props) => {
         <header class={c.ss(`card-header ${headerColour}`)}>
           <a href='/' class={c.ss('has-text-grey-dark')}>
             <span class={c.ss('icon is-large')}>
-              <i class={c.ss('fas fa-arrow-left fa-lg')} />
+              <FontAwesomeIcon icon={faArrowLeft} size='lg' />
             </span>
           </a>
 
           <p class={c.ss('card-header-title is-centered')}>
             {service.meta.providerName}
-            {fetchStatus === statuses.IN_PROGRESS && <i class={c.ss('fas fa-circle-notch fa-spin fa-fw has-text-primary ml-2')} />}
+            {fetchStatus === statuses.IN_PROGRESS && <FontAwesomeIcon spin fixedWidth icon={faCircleNotch} className={c.ss('has-text-primary ml-2')} />}
           </p>
           <span class={c.ss('icon is-large')} />
         </header>

--- a/src/ui/components/detailedPanelBody/index.js
+++ b/src/ui/components/detailedPanelBody/index.js
@@ -4,13 +4,15 @@ import ModularCssHelper from '../../lib/ModularCssHelper.js';
 import CollapsibleSection from '../collapsibleSection';
 import DetailedIncident from '../detailedIncident';
 import statuses from '../../lib/statusConstants.js';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
 const DetailedPanelBody = ({ serviceKey, service, fetchStatus, data }) => {
   if (fetchStatus === statuses.IN_PROGRESS) return (
     <div class={c.ss('has-text-primary has-text-centered')}>
-      <i class={c.ss('fas fa-circle-notch fa-spin fa-5x')} />
+      <FontAwesomeIcon icon={faCircleNotch} spin size='5x' />
       <p class={c.ss('is-size-4 is-italic my-2')}>Checking status...</p>
     </div>
   )

--- a/src/ui/components/header/index.js
+++ b/src/ui/components/header/index.js
@@ -1,6 +1,8 @@
 import { h } from 'preact';
 import style from './style.scss';
 import ModularCssHelper from '../../lib/ModularCssHelper.js';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faLayerGroup } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
@@ -10,7 +12,7 @@ const Header = () => (
 			<div class={c.ss('navbar-brand centered-row')}>
 				<a class={c.ss('navbar-item is-size-4 consistent-colour')} href={'/'}>
 					<span class={c.ss('icon is-medium has-text-grey-dark')}>
-						<i class={c.ss('fas fa-layer-group')} />
+						<FontAwesomeIcon icon={faLayerGroup} />
 					</span>
 					<span>statuses</span>
 					<span>.</span>

--- a/src/ui/components/incidentsSummary/index.js
+++ b/src/ui/components/incidentsSummary/index.js
@@ -1,6 +1,8 @@
 import { h } from 'preact';
 import style from './style.scss';
 import ModularCssHelper from '../../lib/ModularCssHelper.js';
+import { FontAwesomeIcon } from '@aduh95/preact-fontawesome'
+import { faCheckCircle, faExclamationCircle, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 
 const c = new ModularCssHelper(style)
 
@@ -8,17 +10,18 @@ const incidentsSummary = ({ data, type }) => {
   if (!data) return null
   if (data.length === 0) return (
     <p class='has-text-centered'>
-      <i class='fas fa-check-circle has-text-success mr-1' />
+      <FontAwesomeIcon icon={faCheckCircle} className={c.ss('has-text-success mr-1')} />
       No {type} issues
     </p>
   )
 
   const issuePlural = data.length > 1 ? 'issues' : 'issue'
-  const faIcon = type === 'ongoing' ? 'fa-exclamation-circle' : 'fa-exclamation-triangle'
+  const faIcon = type === 'ongoing' ? faExclamationCircle : faExclamationTriangle
   const faColour = type === 'ongoing' ? 'has-text-danger' : 'has-text-warning'
   return (
     <p class='has-text-centered has-text-weight-bold'>
       <i class={`fas ${faIcon} ${faColour} mr-1`} />
+      <FontAwesomeIcon icon={faIcon} className={c.ss(`${faColour} mr-1`)} />
       {data.length} {type} {issuePlural}
     </p>
   )

--- a/src/ui/lib/IncidentMetaFields.js
+++ b/src/ui/lib/IncidentMetaFields.js
@@ -1,4 +1,12 @@
 import moment from 'moment'
+import {
+  faHourglassStart,
+  faHourglassHalf,
+  faHourglassEnd,
+  faServer,
+  faGlobeAmericas
+ } from '@fortawesome/free-solid-svg-icons'
+
 
 export const createTimeDisplay = (timeString) => {
   // Reject non-iso dates to fallback values
@@ -15,28 +23,28 @@ export const metaFields = [
   {
     key: 'startTime',
     uiText: 'Issue start',
-    uiIcon: 'fa-hourglass-start',
+    uiIcon: faHourglassStart,
     exists: (incident) => !!incident.startTime,
     extract: (incident) => createTimeDisplay(incident.startTime)
   },
   {
     key: 'creationTime',
     uiText: 'Incident start',
-    uiIcon: 'fa-hourglass-half',
+    uiIcon: faHourglassHalf,
     exists: (incident) => !!incident.creationTime,
     extract: (incident) => createTimeDisplay(incident.creationTime)
   },
   {
     key: 'resolutionTime',
     uiText: 'Resolved',
-    uiIcon: 'fa-hourglass-end',
+    uiIcon: faHourglassEnd,
     exists: (incident) => !!incident.resolutionTime,
     extract: (incident) => createTimeDisplay(incident.resolutionTime)
   },
   {
     key: 'service',
     uiText: 'Service(s)',
-    uiIcon: 'fa-server',
+    uiIcon: faServer,
     exists: (incident) => incident.service && (incident.service.key || incident.service.name),
     extract: (incident) => {
       const service = incident.service
@@ -48,7 +56,7 @@ export const metaFields = [
   {
     key: 'affectedRegions',
     uiText: 'Region(s)',
-    uiIcon: 'fa-globe-americas',
+    uiIcon: faGlobeAmericas,
     exists: (incident) => incident.affectedRegions && Array.isArray(incident.affectedRegions) && incident.affectedRegions.length > 0,
     extract: (incident) => incident.affectedRegions.join(', ')
   }

--- a/src/ui/sass/global.scss
+++ b/src/ui/sass/global.scss
@@ -3,5 +3,4 @@
 @import "./brand.scss";
 @import "../../../node_modules/bulma/sass/base/_all.sass";
 @import "../../../node_modules/bulma/sass/helpers/_all.sass";
-@import "../../../node_modules/@fortawesome/fontawesome-free/css/all.min.css";
 @import "./utils.scss";


### PR DESCRIPTION
FontAwesome was originally setup to use CSS+Webfonts but this was a heavy weight on the bundle size. Moving over to the react/preact module allows explicit imports and the final bundle doesn't have to include the 1000+ icons we're not even using. This takes away 4-5 files that were ~500kb in the bundle. 